### PR TITLE
Better version diff printing

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=too-few-public-methods,missing-docstring
+disable=too-few-public-methods,missing-docstring,too-many-return-statements
 #print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=too-few-public-methods,missing-docstring,too-many-return-statements
+disable=too-few-public-methods,missing-docstring
 #print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/pikaur/pprint.py
+++ b/pikaur/pprint.py
@@ -68,20 +68,16 @@ def pretty_format_upgradeable(packages_updates, verbose=False, print_repo=False,
     if not color:
         _color_line = _bold_line = lambda x, *args: x
 
-    def get_common_string(str1, str2):
-        result = ''
-        if '' in (str1, str2):
-            return result
-        counter = 0
-        while (
-                counter < len(str1)
-        ) and (
-            counter < len(str2)
-        ) and (
-            str1[counter] == str2[counter]
-        ):
-            result += str1[counter]
-            counter += 1
+    def get_common_version(str1, str2):
+        version_delimiters = ':.-+'
+
+        result = str2
+        while not str1.startswith(result):
+            result = result[:-1]
+
+        while len(result) > 0 and result[-1] not in version_delimeters:
+            result = result[:-1]
+
         return result
 
     def get_version_diff(version, common_version):
@@ -94,7 +90,7 @@ def pretty_format_upgradeable(packages_updates, verbose=False, print_repo=False,
         return new_version_postfix
 
     def pretty_format(pkg_update):
-        common_version = get_common_string(
+        common_version = get_common_version(
             pkg_update.Current_Version, pkg_update.New_Version
         )
         version_color = 10

--- a/pikaur/version.py
+++ b/pikaur/version.py
@@ -49,6 +49,7 @@ class PackageVersion:
 
         return parts
 
+    # pylint: disable=too-many-return-statements
     def compare(self, other):
         '''
         Returns a pair consisting of:


### PR DESCRIPTION
Before the common version string of `2.11.4` and `2.12.3` would be `2.1`.

With this patch it is now `2.`.

I don't know if we would prefer to get `2.` or just `2` as the common version string.
I'm also not sure if I'm missing any version delimiters.