### PR TITLE
Added support for toggling enter key requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ terminal colors, from 0 to 15
 ##### VersionDiffNew (default: 9)
 
 
+#### [UI]
+
+#### RequireEnterConfirm (default: yes)
+require enter key to be pressed when answering questions.
+
+
+
+
+
 
 ### Directories
 

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -56,6 +56,12 @@ _CONFIG_SCHEMA = {
             'type': 'int',
             'default': '9',
         },
+    },
+    'misc': {
+        'RequireEnterConfirm': {
+            'type': 'bool',
+            'default': 'no'
+        }
     }
 }
 

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -60,7 +60,7 @@ _CONFIG_SCHEMA = {
     'misc': {
         'RequireEnterConfirm': {
             'type': 'bool',
-            'default': 'no'
+            'default': 'yes'
         }
     }
 }

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -57,7 +57,7 @@ _CONFIG_SCHEMA = {
             'default': '9',
         },
     },
-    'misc': {
+    'ui': {
         'RequireEnterConfirm': {
             'type': 'bool',
             'default': 'yes'

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -42,7 +42,7 @@ from .async_cmd import CmdTaskWorker
 from .conflicts import find_conflicts
 from .prompt import (
     ask_to_continue, retry_interactive_command,
-    retry_interactive_command_or_exit,
+    retry_interactive_command_or_exit, get_input,
 )
 
 
@@ -381,12 +381,14 @@ class InstallPackagesCLI():
 
         def _confirm_sysupgrade(verbose=False) -> str:
             _print_sysupgrade(verbose=verbose)
-            answer = input('{} {}\n{} {}\n> '.format(
+            prompt = '{} {}\n{} {}\n>>'.format(
                 color_line('::', 12),
-                bold_line(_("Proceed with installation? [Y/n]")),
+                bold_line('Proceed with installation? [Y/n] '),
                 color_line('::', 12),
-                bold_line(_("[v]iew package detail   [m]anually select packages"))
-            ))
+                bold_line('[v]iew package detail   [m]anually select packages'))
+
+            answer = get_input(prompt, 'Ynvm')
+
             return answer
 
         if self.args.noconfirm:
@@ -439,15 +441,17 @@ class InstallPackagesCLI():
                 if self.args.noconfirm:
                     answer = _("a")
                 else:
-                    answer = input('{} {}\n{}\n{}\n{}\n{}\n> '.format(
+                    prompt = '{} {}\n{}\n{}\n{}\n{}\n> '.format(
                         color_line('::', 11),
-                        _("Try recovering?"),
-                        _("[c] git checkout -- '*'"),
-                        # _("[c] git checkout -- '*' ; git clean -f -d -x"),
-                        _("[r] remove dir and clone again"),
-                        _("[s] skip this package"),
-                        _("[a] abort"),
-                    ))
+                        'Try recovering?',
+                        "[c] git checkout -- '*'",
+                        # "[c] git checkout -- '*' ; git clean -f -d -x",
+                        '[r] remove dir and clone again',
+                        '[s] skip this package',
+                        '[a] abort')
+
+                    answer = get_input(prompt, 'crsA')
+
                 answer = answer.lower()[0]
                 if answer == _("c"):
                     package_build.git_reset_changed()

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -383,9 +383,9 @@ class InstallPackagesCLI():
             _print_sysupgrade(verbose=verbose)
             prompt = '{} {}\n{} {}\n>>'.format(
                 color_line('::', 12),
-                bold_line('Proceed with installation? [Y/n] '),
+                bold_line(_('Proceed with installation? [Y/n] ')),
                 color_line('::', 12),
-                bold_line('[v]iew package detail   [m]anually select packages'))
+                bold_line(_('[v]iew package detail   [m]anually select packages')))
 
             answer = get_input(prompt, 'Ynvm')
 
@@ -443,12 +443,12 @@ class InstallPackagesCLI():
                 else:
                     prompt = '{} {}\n{}\n{}\n{}\n{}\n> '.format(
                         color_line('::', 11),
-                        'Try recovering?',
-                        "[c] git checkout -- '*'",
-                        # "[c] git checkout -- '*' ; git clean -f -d -x",
-                        '[r] remove dir and clone again',
-                        '[s] skip this package',
-                        '[a] abort')
+                        _("Try recovering?"),
+                        _("[c] git checkout -- '*'"),
+                        # _("[c] git checkout -- '*' ; git clean -f -d -x"),
+                        _("[r] remove dir and clone again"),
+                        _("[s] skip this package"),
+                        _("[a] abort"))
 
                     answer = get_input(prompt, 'crsA')
 

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -61,9 +61,9 @@ def get_input(prompt: str, answers: str=None) -> str:
     return answer
 
 
-def ask_to_continue(text: str, default_yes: bool=True, args: PikaurArgs=None) -> bool:
+def ask_to_continue(text: str=None, default_yes: bool=True, args: PikaurArgs=None) -> bool:
     if text is None:
-        text = 'Do you want to proceed?'
+        text = _('Do you want to proceed?')
 
     if args and args.noconfirm and default_yes:
         print_status_message('{} {}'.format(text, _("[Y]es (--noconfirm)")))

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -2,9 +2,8 @@ import sys
 import tty
 from typing import Callable, List
 
-from pikaur.config import PikaurConfig
-
-from pikaur.args import PikaurArgs
+from .args import PikaurArgs
+from .config import PikaurConfig
 
 from .core import interactive_spawn
 from .i18n import _

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -2,13 +2,13 @@ import sys
 import tty
 from typing import Callable, List
 
+from pikaur.config import PikaurConfig
+
 from pikaur.args import PikaurArgs
 
 from .core import interactive_spawn
 from .i18n import _
 from .pprint import color_line, print_status_message
-
-REQUIRE_PRESS_ENTER = False  # TODO Load this from config file
 
 
 def get_answer(question, answers='Yn'):
@@ -54,7 +54,7 @@ def get_answer(question, answers='Yn'):
 
 
 def get_input(prompt: str, answers: str=None):
-    if REQUIRE_PRESS_ENTER:
+    if PikaurConfig().misc.get('RequireEnterConfirm'):
         answer = input(prompt).lower()
     else:
         answer = get_answer(prompt, answers=answers)

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -53,7 +53,7 @@ def get_answer(question: str, answers: str='Yn') -> str:
 
 
 def get_input(prompt: str, answers: str=None) -> str:
-    if PikaurConfig().misc.get('RequireEnterConfirm'):
+    if PikaurConfig().ui.get('RequireEnterConfirm'):
         answer = input(prompt).lower()
     else:
         answer = get_answer(prompt, answers=answers)

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -29,7 +29,7 @@ def read_answer_from_tty(question: str, answers: str = 'Yn') -> str:
         return default
 
     print(question, flush=True, end=" ")
-    previous_tty_settings = tty.tcgetattr(sys.stdin.fileno())
+    previous_tty_settings = tty.tcgetattr(sys.stdin.fileno())  # type: ignore
     try:
         tty.setraw(sys.stdin.fileno())
         answer = sys.stdin.read(1).lower()
@@ -47,9 +47,9 @@ def read_answer_from_tty(question: str, answers: str = 'Yn') -> str:
     except Exception:
         return ' '
     finally:
-        tty.tcsetattr(sys.stdin.fileno(), tty.TCSADRAIN, previous_tty_settings)
+        tty.tcsetattr(sys.stdin.fileno(), tty.TCSADRAIN, previous_tty_settings)  # type: ignore
         sys.stdout.write('{}\r\n'.format(answer))
-        tty.tcdrain(sys.stdin.fileno())
+        tty.tcdrain(sys.stdin.fileno())  # type: ignore
 
 
 def get_input(prompt: str, answers=None) -> str:
@@ -77,7 +77,6 @@ def ask_to_continue(text: str = None, default_yes: bool = True, args: PikaurArgs
 
 
 def ask_to_retry_decorator(fun: Callable) -> Callable:
-
     def decorated(*args, **kwargs):
         while True:
             result = fun(*args, **kwargs)

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -61,7 +61,10 @@ def get_input(prompt: str, answers: str=None) -> str:
     return answer
 
 
-def ask_to_continue(text: str='Do you want to proceed?', default_yes: bool=True, args: PikaurArgs=None) -> bool:
+def ask_to_continue(text: str, default_yes: bool=True, args: PikaurArgs=None) -> bool:
+    if text is None:
+        text = 'Do you want to proceed?'
+
     if args and args.noconfirm and default_yes:
         print_status_message('{} {}'.format(text, _("[Y]es (--noconfirm)")))
 

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -2,11 +2,13 @@ import sys
 import tty
 from typing import Callable, List
 
+from pikaur.args import PikaurArgs
+
 from .core import interactive_spawn
 from .i18n import _
 from .pprint import color_line, print_status_message
 
-REQUIRE_PRESS_ENTER = True  # TODO Load this from config file
+REQUIRE_PRESS_ENTER = False  # TODO Load this from config file
 
 
 def get_answer(question, answers='Yn'):
@@ -60,7 +62,10 @@ def get_input(prompt: str, answers: str=None):
     return answer
 
 
-def ask_to_continue(text='Do you want to proceed?', default_yes=True):
+def ask_to_continue(text='Do you want to proceed?', default_yes=True, args: PikaurArgs=None) -> bool:
+    if args and args.noconfirm and default_yes:
+        print_status_message('{} {}'.format(text, _("[Y]es (--noconfirm)")))
+
     prompt = text + (' [Y/n] ' if default_yes else ' [y/N] ')
     answers = 'Yn' if default_yes else 'yN'
 

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -10,7 +10,7 @@ from .i18n import _
 from .pprint import color_line, print_status_message
 
 
-def get_answer(question: str, answers: str='Yn') -> str:
+def read_answer_from_tty(question: str, answers='Yn') -> str:
     '''
     Function displays a question and reads a single character
     from STDIN as an answer. Then returns the character as lower character.
@@ -52,11 +52,11 @@ def get_answer(question: str, answers: str='Yn') -> str:
         tty.tcdrain(sys.stdin.fileno())
 
 
-def get_input(prompt: str, answers: str=None) -> str:
+def get_input(prompt: str, answers=None) -> str:
     if PikaurConfig().ui.get('RequireEnterConfirm'):
         answer = input(prompt).lower()
     else:
-        answer = get_answer(prompt, answers=answers)
+        answer = read_answer_from_tty(prompt, answers=answers)
 
     return answer
 

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -10,7 +10,7 @@ from .i18n import _
 from .pprint import color_line, print_status_message
 
 
-def get_answer(question, answers='Yn'):
+def get_answer(question: str, answers: str='Yn') -> str:
     '''
     Function displays a question and reads a single character
     from STDIN as an answer. Then returns the character as lower character.
@@ -52,7 +52,7 @@ def get_answer(question, answers='Yn'):
         tty.tcdrain(sys.stdin.fileno())
 
 
-def get_input(prompt: str, answers: str=None):
+def get_input(prompt: str, answers: str=None) -> str:
     if PikaurConfig().misc.get('RequireEnterConfirm'):
         answer = input(prompt).lower()
     else:
@@ -61,7 +61,7 @@ def get_input(prompt: str, answers: str=None):
     return answer
 
 
-def ask_to_continue(text='Do you want to proceed?', default_yes=True, args: PikaurArgs=None) -> bool:
+def ask_to_continue(text: str='Do you want to proceed?', default_yes: bool=True, args: PikaurArgs=None) -> bool:
     if args and args.noconfirm and default_yes:
         print_status_message('{} {}'.format(text, _("[Y]es (--noconfirm)")))
 

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -10,7 +10,7 @@ from .i18n import _
 from .pprint import color_line, print_status_message
 
 
-def read_answer_from_tty(question: str, answers='Yn') -> str:
+def read_answer_from_tty(question: str, answers: str = 'Yn') -> str:
     '''
     Function displays a question and reads a single character
     from STDIN as an answer. Then returns the character as lower character.
@@ -61,7 +61,7 @@ def get_input(prompt: str, answers=None) -> str:
     return answer
 
 
-def ask_to_continue(text: str=None, default_yes: bool=True, args: PikaurArgs=None) -> bool:
+def ask_to_continue(text: str = None, default_yes: bool = True, args: PikaurArgs = None) -> bool:
     if text is None:
         text = _('Do you want to proceed?')
 

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -64,10 +64,10 @@ def get_input(prompt: str, answers: str=None) -> str:
 def ask_to_continue(text: str=None, default_yes: bool=True, args: PikaurArgs=None) -> bool:
     if text is None:
         text = _('Do you want to proceed?')
-        return True
 
     if args and args.noconfirm and default_yes:
         print_status_message('{} {}'.format(text, _("[Y]es (--noconfirm)")))
+        return True
 
     prompt = text + (' [Y/n] ' if default_yes else ' [y/N] ')
     answers = 'Yn' if default_yes else 'yN'

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -64,6 +64,7 @@ def get_input(prompt: str, answers: str=None) -> str:
 def ask_to_continue(text: str=None, default_yes: bool=True, args: PikaurArgs=None) -> bool:
     if text is None:
         text = _('Do you want to proceed?')
+        return True
 
     if args and args.noconfirm and default_yes:
         print_status_message('{} {}'.format(text, _("[Y]es (--noconfirm)")))


### PR DESCRIPTION
Currently a constant at the top of `prompt`, a boolean can be toggled to switch between built-in `input` function for requiring enter key or custom `get_answer` function which does not require enter key confirmation.

Requires integrating with the config file.

_edited_:
closes #83