### PR TITLE
change readme [ui] config header case

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ terminal colors, from 0 to 15
 ##### VersionDiffNew (default: 9)
 
 
-#### [UI]
+#### [ui]
 
 #### RequireEnterConfirm (default: yes)
 require enter key to be pressed when answering questions.


### PR DESCRIPTION
This is a tiny fix. ConfigParser seems to care about the case in headers, so we should be truthful in the README. 

As proof of the current "issue", I added a section with [UI] in caps before updating to 0.9.2 and ended up with this:
```
[UI]
requireenterconfirm = no

[ui]
requireenterconfirm = yes
```
lol