### PR TITLE
Reduce text size to match other settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ terminal colors, from 0 to 15
 
 #### [ui]
 
-#### RequireEnterConfirm (default: yes)
+##### RequireEnterConfirm (default: yes)
 require enter key to be pressed when answering questions.
 
 


### PR DESCRIPTION
Setting was same text size as heading; reduced to match other settings.