### PR TITLE
Add extra space in confirmation prompt

### DIFF
--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -404,7 +404,7 @@ class InstallPackagesCLI():
 
         def _confirm_sysupgrade(verbose=False) -> str:
             _print_sysupgrade(verbose=verbose)
-            prompt = '{} {}\n{} {}\n>>'.format(
+            prompt = '{} {}\n{} {}\n>> '.format(
                 color_line('::', 12),
                 bold_line(_('Proceed with installation? [Y/n] ')),
                 color_line('::', 12),


### PR DESCRIPTION
Instead of `>>y`, see `>> y` in the cli prompt

Before:
![screenshot from 2018-04-06 11-40-11](https://user-images.githubusercontent.com/564822/38414754-b32754e6-398f-11e8-9129-7c4b4297c6ca.png)

After:
![screenshot from 2018-04-06 11-41-03](https://user-images.githubusercontent.com/564822/38414763-b9bbb43c-398f-11e8-83cc-12969cbe651b.png)

This is a critical fix obviously !