### PR TITLE
Show if package is out of date 

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-07 14:22+0200\n"
+"POT-Creation-Date: 2018-04-12 19:10+0100\n"
 "PO-Revision-Date: 2018-04-07 14:35+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,17 +32,17 @@ msgstr[1] "Zu installierende AUR-Pakete:"
 msgid "Build directory: {}"
 msgstr "Build-Verzeichnis: {}"
 
-#: pikaur/install_cli.py:663
+#: pikaur/install_cli.py:678
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "'{name}' kann nicht gebaut werden."
 
-#: pikaur/install_cli.py:484
+#: pikaur/install_cli.py:504
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "'{name}' in '{path}' kann nicht vom AUR geklont werden:"
 
-#: pikaur/install_cli.py:486
+#: pikaur/install_cli.py:506
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "'{name}' in '{path} kann nicht vom AUR bezogen werden:"
@@ -51,19 +51,19 @@ msgstr "'{name}' in '{path} kann nicht vom AUR bezogen werden:"
 msgid "Command '{}' failed to execute."
 msgstr "Ausführung des Befehls '{}' ist fehlgeschlagen."
 
-#: pikaur/args.py:58
+#: pikaur/args.py:63
 msgid "Common pacman options:"
 msgstr "Allgemeine Pacman-Optionen:"
 
-#: pikaur/install_cli.py:246
+#: pikaur/install_cli.py:266
 msgid "Dependencies missing for {}"
 msgstr "Fehlende Abhängigkeiten für {}"
 
-#: pikaur/install_cli.py:680
+#: pikaur/install_cli.py:695
 msgid "Dependency cycle detected between {}"
 msgstr "Abhängigkeitsschleife entdeckt zwischen {}"
 
-#: pikaur/install_cli.py:191
+#: pikaur/install_cli.py:208
 msgid "Do you want to proceed without editing?"
 msgstr "Ohne editieren fortfahren?"
 
@@ -71,7 +71,7 @@ msgstr "Ohne editieren fortfahren?"
 msgid "Do you want to proceed?"
 msgstr "Fortsetzen?"
 
-#: pikaur/install_cli.py:550
+#: pikaur/install_cli.py:570
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Soll '{installed}' gelöscht werden?"
@@ -84,17 +84,23 @@ msgstr "Sollen alle Dateien gelöscht werden?"
 msgid "Do you want to retry?"
 msgstr "Erneut versuchen?"
 
-#: pikaur/install_cli.py:601
+#: pikaur/install_cli.py:616
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Build-Dateien {diff} für {name} anzeigen?"
 
-#: pikaur/install_cli.py:567
+#: pikaur/install_cli.py:587
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "{edit} {file} für Paket {name}?"
 
-#: pikaur/install_cli.py:157
+#: pikaur/build.py:204
+msgid "Downloading the latest sources for a devel package {}"
+msgid_plural "Downloading the latest sources for devel packages {}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pikaur/install_cli.py:174
 msgid "Failed to build following packages:"
 msgstr "Der Bau folgender Pakete ist fehlgeschlagen:"
 
@@ -106,7 +112,7 @@ msgstr "Folgende Pakete können im AUR nicht gefunden werden:"
 msgid "Ignoring package {}"
 msgstr "Ignoriere Paket {}"
 
-#: pikaur/build.py:235
+#: pikaur/build.py:256
 msgid "Installing already built dependencies for {}"
 msgstr "Installiere bereits gebaute Abhängigkeit für {}"
 
@@ -116,31 +122,31 @@ msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Zu installierende Abhängigkeit aus dem AUR:"
 msgstr[1] "Zu installierende Abhängigkeiten aus dem AUR:"
 
-#: pikaur/install_cli.py:545
+#: pikaur/install_cli.py:565
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr ""
 "Neues Paket '{new}' steht in Konflikt mit bereits installiertem Paket "
 "'{installed}'."
 
-#: pikaur/install_cli.py:535
+#: pikaur/install_cli.py:555
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Neue Pakete '{new}' und '{other}' stehen in Konflikt."
 
-#: pikaur/install_cli.py:235
+#: pikaur/install_cli.py:255
 msgid "Nothing to do."
 msgstr "Nichts zu tun."
 
-#: pikaur/args.py:76
+#: pikaur/args.py:81
 msgid "Pikaur-specific options:"
 msgstr "Pikaur-spezifische Optionen:"
 
-#: pikaur/install_cli.py:420
+#: pikaur/install_cli.py:440
 msgid "Proceed with installation? [Y/n] "
 msgstr "Mit Installation fortfahren? [J/n] "
 
-#: pikaur/package_update.py:94
+#: pikaur/package_update.py:99
 msgid "Reading AUR package info..."
 msgid_plural "Reading AUR packages info..."
 msgstr[0] "Lese AUR Paketinformationen..."
@@ -160,21 +166,21 @@ msgid_plural "Repository packages will be installed:"
 msgstr[0] "Zu installierendes Repository-Paket:"
 msgstr[1] "Zu installierende Repository-Pakete:"
 
-#: pikaur/install_cli.py:336
+#: pikaur/install_cli.py:356
 msgid "Resolving AUR dependencies..."
 msgstr "Löse AUR-Abhängigkeiten auf..."
 
-#: pikaur/install_cli.py:757
+#: pikaur/install_cli.py:772
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Mache Transaktion {target} rückgängig..."
 
-#: pikaur/search_cli.py:158
+#: pikaur/search_cli.py:172
 #, python-brace-format
 msgid "Searching... [{bar}]"
 msgstr "Suche... [{bar}]"
 
-#: pikaur/install_cli.py:559
+#: pikaur/install_cli.py:579
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Überspringe Review von {file} für {name} Paket ({flag})"
@@ -189,11 +195,11 @@ msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Zu installierendes 3rd-Party Repository-Paket:"
 msgstr[1] "Zu installierende 3rd-Party Repository-Pakete:"
 
-#: pikaur/install_cli.py:500
+#: pikaur/install_cli.py:520
 msgid "Try recovering?"
 msgstr "Versuchen wiederherzustellen?"
 
-#: pikaur/install_cli.py:251
+#: pikaur/install_cli.py:271
 msgid "Version mismatch:"
 msgstr "Versionskonflikt:"
 
@@ -205,74 +211,74 @@ msgstr "[N]ein (--noconfirm)"
 msgid "[Y]es (--noconfirm)"
 msgstr "[J]a (--noconfirm)"
 
-#: pikaur/install_cli.py:505
+#: pikaur/install_cli.py:525
 msgid "[a] abort"
 msgstr "[a] abbrechen"
 
-#: pikaur/install_cli.py:501
+#: pikaur/install_cli.py:521
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
-#: pikaur/search_cli.py:128
+#: pikaur/search_cli.py:130
 #, python-brace-format
 msgid "[installed: {version}]"
 msgstr "[installiert: {version}]"
 
-#: pikaur/search_cli.py:132
+#: pikaur/search_cli.py:134
 msgid "[installed]"
 msgstr "[installiert]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:503
+#: pikaur/install_cli.py:523
 msgid "[r] remove dir and clone again"
 msgstr "[e] entferne Verzeichnis und klone erneut"
 
-#: pikaur/install_cli.py:504
+#: pikaur/install_cli.py:524
 msgid "[s] skip this package"
 msgstr "[u] Paket überspringen"
 
-#: pikaur/install_cli.py:422
+#: pikaur/install_cli.py:442
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[P]aketdetails anzeigen [m]anuell selektierte Pakete"
 
-#: pikaur/install_cli.py:496
+#: pikaur/install_cli.py:516
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:510
+#: pikaur/install_cli.py:530
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:602
+#: pikaur/install_cli.py:617
 msgid "diff"
 msgstr "Unterschied"
 
-#: pikaur/args.py:68
+#: pikaur/args.py:73
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr ""
 "Nicht nachfragen, ob PKGBUILDs und andere Dateien editiert werden sollen"
 
-#: pikaur/args.py:71
+#: pikaur/args.py:76
 msgid "don't remove build dir after the build"
 msgstr "Build-Verzeichnis nach dem Bauen nicht löschen"
 
-#: pikaur/main.py:246
+#: pikaur/main.py:247
 msgid "don't run me as root."
 msgstr "Führe mich nicht als root aus."
 
-#: pikaur/install_cli.py:568
+#: pikaur/install_cli.py:588
 msgid "edit"
 msgstr "Editiere"
 
-#: pikaur/install_cli.py:679
+#: pikaur/install_cli.py:694
 msgid "error:"
 msgstr "Fehler:"
 
-#: pikaur/install_cli.py:524
+#: pikaur/install_cli.py:544
 msgid "looking for conflicting packages..."
 msgstr "Suche nach in Konflikt stehenden Pakten..."
 
-#: pikaur/install_cli.py:441
+#: pikaur/install_cli.py:461
 msgid "m"
 msgstr "m"
 
@@ -280,58 +286,57 @@ msgstr "m"
 msgid "n"
 msgstr "n"
 
-#: pikaur/install_cli.py:188
+#: pikaur/install_cli.py:205
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr "Kein Editor gefunden. Versuchen Sie $VISUAL oder $EDITOR zu setzen."
 
-#: pikaur/main.py:253
+#: pikaur/search_cli.py:151
+msgid "outofdate"
+msgstr ""
+
+#: pikaur/main.py:254
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr ""
 "Pikaur benötigt systemd >= 235 (dynamic users) um als root ausgeführt werden "
 "zu können."
 
-#: pikaur/args.py:63
+#: pikaur/args.py:68
 msgid "query packages from AUR only"
 msgstr "Nur AUR-Pakete abfragen"
 
-#: pikaur/args.py:64
+#: pikaur/args.py:69
 msgid "query packages from repository only"
 msgstr "Nur Repository-Pakete abfragem"
 
-#: pikaur/install_cli.py:512
+#: pikaur/install_cli.py:532
 msgid "r"
 msgstr "e"
 
-#: pikaur/install_cli.py:514
+#: pikaur/install_cli.py:534
 msgid "s"
 msgstr "u"
 
-#: pikaur/args.py:69
+#: pikaur/args.py:74
 msgid "search only in package names"
 msgstr "Nur in Paketnamen suchen"
 
-#: pikaur/args.py:70
+#: pikaur/args.py:75
 msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr "sysupgrade '-git' und andere dev Pakete älter als 1 Tag"
 
-#: pikaur/install_cli.py:439
+#: pikaur/install_cli.py:459
 msgid "v"
 msgstr "p"
 
-#: pikaur/install_cli.py:544 pikaur/install_cli.py:592 pikaur/pprint.py:68
+#: pikaur/install_cli.py:88 pikaur/install_cli.py:564 pikaur/pprint.py:68
 msgid "warning:"
 msgstr "Warnung:"
 
-#: pikaur/install_cli.py:437 pikaur/prompt.py:13
+#: pikaur/prompt.py:13 pikaur/install_cli.py:457
 msgid "y"
 msgstr "j"
 
-#: pikaur/install_cli.py:593
-#, python-brace-format
-msgid "{name} AUR repository is up to date - skipping"
-msgstr "AUR-Repository {name} ist aktuell - überspringe"
-
-#: pikaur/install_cli.py:635
+#: pikaur/install_cli.py:650
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
@@ -339,7 +344,12 @@ msgstr ""
 "{name} kann auf der aktuellen Architektur ({arch}) nicht gebaut werden. "
 "Unterstützt wird: {suparch}"
 
-#: pikaur/install_cli.py:252
+#: pikaur/install_cli.py:89
+#, fuzzy, python-brace-format
+msgid "{name} {version} {package_source} package is up to date - skipping"
+msgstr "AUR-Repository {name} ist aktuell - überspringe"
+
+#: pikaur/install_cli.py:272
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -348,6 +358,6 @@ msgstr ""
 "{what} häng ab von: '{dep}'\n"
 " gefunden in '{location}': '{version}'"
 
-#: pikaur/build.py:285
+#: pikaur/build.py:306
 msgid "{} does not exist on the filesystem."
 msgstr "{} existiert nicht im Dateisystem."

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-03 16:38+0100\n"
+"POT-Creation-Date: 2018-04-12 19:10+0100\n"
 "PO-Revision-Date: 2018-03-03 16:29+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,315 +18,328 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: pikaur/pprint.py:168
+#: pikaur/pprint.py:105
+msgid "({} days old)"
+msgstr ""
+
+#: pikaur/pprint.py:193
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "Le paquet de l'AUR sera installé :"
 msgstr[1] "Les paquets de l'AUR seront installés :"
 
-#: pikaur/main.py:105
-msgid "Already up-to-date."
-msgstr "Déjà à jour."
-
-#: pikaur/main.py:136
+#: pikaur/main.py:160
 msgid "Build directory: {}"
 msgstr "Dossier de build : {}"
 
-#: pikaur/install_cli.py:532
+#: pikaur/install_cli.py:678
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "Impossible de construire '{name}'."
 
-#: pikaur/install_cli.py:332
+#: pikaur/install_cli.py:504
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "Impossible de cloner '{name}' dans '{path}' depuis l'AUR :"
 
-#: pikaur/install_cli.py:334
+#: pikaur/install_cli.py:506
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "Impossible de rapatrier '{name}' dans '{path}' depuis l'AUR :"
 
-#: pikaur/prompt.py:39
+#: pikaur/prompt.py:93
 msgid "Command '{}' failed to execute."
 msgstr "La commande '{}' a échoué."
 
-#: pikaur/main.py:160
+#: pikaur/args.py:63
 msgid "Common pacman options:"
 msgstr "Options standards de pacman :"
 
-#: pikaur/install_cli.py:193
+#: pikaur/install_cli.py:266
 msgid "Dependencies missing for {}"
 msgstr "Dépendances manquantes pour {}"
 
-#: pikaur/install_cli.py:544
+#: pikaur/install_cli.py:695
 msgid "Dependency cycle detected between {}"
 msgstr "Cycle de dépendances détecté entre {}"
 
-#: pikaur/install_cli.py:57
+#: pikaur/install_cli.py:208
 msgid "Do you want to proceed without editing?"
 msgstr "Continuer sans modifier ?"
 
-#: pikaur/prompt.py:8
+#: pikaur/prompt.py:72
 msgid "Do you want to proceed?"
 msgstr "Continuer ?"
 
-#: pikaur/install_cli.py:394
+#: pikaur/install_cli.py:570
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Supprimer '{installed}' ?"
 
-#: pikaur/main.py:139
+#: pikaur/main.py:163
 msgid "Do you want to remove all files?"
 msgstr "Supprimer tous les fichiers ?"
 
-#: pikaur/prompt.py:29
+#: pikaur/prompt.py:97
 msgid "Do you want to retry?"
 msgstr "Réessayer ?"
 
-#: pikaur/install_cli.py:473
+#: pikaur/install_cli.py:616
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Visualiser les {diff} des fichiers de build pour le paquet {name} ?"
 
-#: pikaur/install_cli.py:445
+#: pikaur/install_cli.py:587
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "{edit} {file} pour le paquet {name} ?"
 
-#: pikaur/install_cli.py:150
+#: pikaur/build.py:204
+msgid "Downloading the latest sources for a devel package {}"
+msgid_plural "Downloading the latest sources for devel packages {}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pikaur/install_cli.py:174
 msgid "Failed to build following packages:"
 msgstr "Impossible de construire les paquets suivants :"
 
-#: pikaur/pprint.py:64
+#: pikaur/pprint.py:69
 msgid "Following packages cannot be found in AUR:"
 msgstr "Les paquets suivants sont introuvables dans l'AUR :"
 
-#: pikaur/aur.py:310
-msgid "Getting ALL AUR info"
-msgstr "Contenu de l'AUR"
-
-#: pikaur/install_cli.py:166
+#: pikaur/install_cli.py:69
 msgid "Ignoring package {}"
 msgstr "Paquet {} ignoré"
 
-#: pikaur/build.py:244
+#: pikaur/build.py:256
 msgid "Installing already built dependencies for {}"
 msgstr "Installation des dépendances déjà construites pour {}"
 
-#: pikaur/build.py:277
-msgid "Installing repository dependencies for {}"
-msgstr "Installation des dépendances du dépôt pour {}"
-
-#: pikaur/pprint.py:178
+#: pikaur/pprint.py:204
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "La nouvelle dépendance sera installée depuis l'AUR :"
 msgstr[1] "Les nouvelles dépendances seront installées depuis l'AUR :"
 
-#: pikaur/install_cli.py:389
+#: pikaur/install_cli.py:565
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr ""
 "Le nouveau paquet '{new}' est en conflit avec le paquet installé "
 "'{installed}'."
 
-#: pikaur/install_cli.py:424
-#, python-brace-format
-msgid "New package '{new}' replaces installed '{installed}' Proceed?"
-msgstr ""
-"Le nouveau paquet '{new}' remplace le paquet installé '{installed}'. "
-"Continuer ?"
-
-#: pikaur/install_cli.py:381
+#: pikaur/install_cli.py:555
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Les nouveaux paquets '{new}' et '{other}' sont en conflit."
 
-#: pikaur/install_cli.py:115
+#: pikaur/install_cli.py:255
 msgid "Nothing to do."
 msgstr "Rien à faire."
 
-#: pikaur/main.py:169
+#: pikaur/args.py:81
 msgid "Pikaur-specific options:"
 msgstr "Options spécifiques pikaur :"
 
-#: pikaur/install_cli.py:285
-msgid "Proceed with installation? [Y/n]"
+#: pikaur/install_cli.py:440
+#, fuzzy
+msgid "Proceed with installation? [Y/n] "
 msgstr "Commencer l'installation ? [O/n]"
 
-#: pikaur/package_update.py:45
-msgid "Reading AUR packages info..."
-msgstr "Lecture des paquets de l'AUR…"
+#: pikaur/package_update.py:99
+#, fuzzy
+msgid "Reading AUR package info..."
+msgid_plural "Reading AUR packages info..."
+msgstr[0] "Lecture des paquets de l'AUR…"
+msgstr[1] "Lecture des paquets de l'AUR…"
 
-#: pikaur/pacman.py:160
+#: pikaur/pacman.py:148
 msgid "Reading local package database..."
 msgstr "Lecture de la base locale de paquets…"
 
-#: pikaur/pacman.py:175
+#: pikaur/pacman.py:192
 msgid "Reading repository package databases..."
 msgstr "Lecture des bases de données de paquets..."
 
-#: pikaur/build.py:383
-msgid "Removing already installed dependencies for {}"
-msgstr "Suppression des dépendances déjà installées pour {}"
-
-#: pikaur/build.py:304
-msgid "Removing make dependencies for {}"
-msgstr "Suppression des dépendances de construction pour {}"
-
-#: pikaur/pprint.py:148
+#: pikaur/pprint.py:170
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "Le paquet du dépôt sera installé :"
 msgstr[1] "Les paquets du dépôt seront installés :"
 
-#: pikaur/install_cli.py:615
+#: pikaur/install_cli.py:356
+#, fuzzy
+msgid "Resolving AUR dependencies..."
+msgstr "résolution des dépendances…"
+
+#: pikaur/install_cli.py:772
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Annulation de la transaction {target}…"
 
-#: pikaur/search_cli.py:135
+#: pikaur/search_cli.py:172
 #, python-brace-format
 msgid "Searching... [{bar}]"
 msgstr "Recherche… [{bar}]"
 
-#: pikaur/install_cli.py:437
+#: pikaur/install_cli.py:579
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Revue de {file} pour le paquet {name} ignorée ({flag})"
 
-#: pikaur/main.py:80
+#: pikaur/main.py:108
 msgid "Starting full AUR upgrade..."
 msgstr "Démarrage de la mise à jour complète AUR…"
 
-#: pikaur/main.py:71
-msgid "Starting full system upgrade..."
-msgstr "Démarrage de la mise à jour complète du système…"
-
-#: pikaur/pprint.py:158
+#: pikaur/pprint.py:182
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Le paquet de dépôt tiers sera installé :"
 msgstr[1] "Les paquets de dépôt tiers seront installés :"
 
-#: pikaur/install_cli.py:344
+#: pikaur/install_cli.py:520
 msgid "Try recovering?"
 msgstr "Essayer de récupérer ?"
 
-#: pikaur/install_cli.py:198
+#: pikaur/install_cli.py:271
 msgid "Version mismatch:"
 msgstr "Inadéquation des versions :"
 
-#: pikaur/prompt.py:12
-msgid "[Y/n]"
-msgstr "[O/n]"
+#: pikaur/prompt.py:77
+#, fuzzy
+msgid "[N]o (--noconfirm)"
+msgstr "[O]ui (--noconfirm)"
 
-#: pikaur/prompt.py:10
+#: pikaur/prompt.py:77
 msgid "[Y]es (--noconfirm)"
 msgstr "[O]ui (--noconfirm)"
 
-#: pikaur/install_cli.py:349
+#: pikaur/install_cli.py:525
 msgid "[a] abort"
 msgstr "[a] annuler"
 
-#: pikaur/install_cli.py:345
+#: pikaur/install_cli.py:521
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
-#: pikaur/search_cli.py:105
+#: pikaur/search_cli.py:130
 #, python-brace-format
 msgid "[installed: {version}]"
 msgstr "[installé : {version}]"
 
-#: pikaur/search_cli.py:109
+#: pikaur/search_cli.py:134
 msgid "[installed]"
 msgstr "[installé]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:347
+#: pikaur/install_cli.py:523
 msgid "[r] remove dir and clone again"
 msgstr "[r] supprimer et cloner à nouveau"
 
-#: pikaur/install_cli.py:348
+#: pikaur/install_cli.py:524
 msgid "[s] skip this package"
 msgstr "[s] sauter ce paquet"
 
-#: pikaur/install_cli.py:287
+#: pikaur/install_cli.py:442
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[v]oir les détails du paquet   sélectionner [m]anuellement les paquets"
 
-#: pikaur/prompt.py:12
-msgid "[y/N]"
-msgstr "[o/N]"
-
-#: pikaur/install_cli.py:340
+#: pikaur/install_cli.py:516
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:352
+#: pikaur/install_cli.py:530
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:474
+#: pikaur/install_cli.py:617
 msgid "diff"
 msgstr "différences"
 
-#: pikaur/main.py:163
+#: pikaur/args.py:73
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "ne pas demander de modifier les PKGBUILD et autres fichiers de build"
 
+#: pikaur/args.py:76
+msgid "don't remove build dir after the build"
+msgstr ""
+
+#: pikaur/main.py:247
+msgid "don't run me as root."
+msgstr ""
+
 # wrong case on purpose
-#: pikaur/install_cli.py:446
+#: pikaur/install_cli.py:588
 msgid "edit"
 msgstr "Modifier"
 
-#: pikaur/install_cli.py:543
+#: pikaur/install_cli.py:694
 msgid "error:"
 msgstr "erreur :"
 
-#: pikaur/install_cli.py:304
+#: pikaur/install_cli.py:544
+msgid "looking for conflicting packages..."
+msgstr ""
+
+#: pikaur/install_cli.py:461
 msgid "m"
 msgstr "m"
 
-#: pikaur/install_cli.py:54
+#: pikaur/prompt.py:14
+msgid "n"
+msgstr ""
+
+#: pikaur/install_cli.py:205
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr "pas d'éditeur trouvé. Essayez de définir $VISUAL ou $EDITOR."
 
-#: pikaur/main.py:244
+#: pikaur/search_cli.py:151
+msgid "outofdate"
+msgstr ""
+
+#: pikaur/main.py:254
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr ""
 "pikaur nécessite systemd ≥ 235 (“dynamic users”) pour être lancé en root."
 
-#: pikaur/install_cli.py:354
+#: pikaur/args.py:68
+msgid "query packages from AUR only"
+msgstr ""
+
+#: pikaur/args.py:69
+msgid "query packages from repository only"
+msgstr ""
+
+#: pikaur/install_cli.py:532
 msgid "r"
 msgstr "r"
 
-#: pikaur/install_cli.py:182
-msgid "resolving dependencies..."
-msgstr "résolution des dépendances…"
-
-#: pikaur/install_cli.py:356
+#: pikaur/install_cli.py:534
 msgid "s"
 msgstr "s"
 
-#: pikaur/main.py:164
+#: pikaur/args.py:74
 msgid "search only in package names"
 msgstr "chercher uniquement dans les noms des paquets"
 
-#: pikaur/install_cli.py:302
+#: pikaur/args.py:75
+msgid "sysupgrade '-git' and other dev packages older than 1 day"
+msgstr ""
+
+#: pikaur/install_cli.py:459
 msgid "v"
 msgstr "v"
 
-#: pikaur/install_cli.py:388 pikaur/install_cli.py:468 pikaur/pprint.py:63
+#: pikaur/install_cli.py:88 pikaur/install_cli.py:564 pikaur/pprint.py:68
 msgid "warning:"
 msgstr "attention :"
 
-#: pikaur/install_cli.py:300 pikaur/prompt.py:14 pikaur/prompt.py:17
+#: pikaur/prompt.py:13 pikaur/install_cli.py:457
 msgid "y"
 msgstr "o"
 
-#: pikaur/install_cli.py:505
+#: pikaur/install_cli.py:650
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
@@ -334,12 +347,12 @@ msgstr ""
 "{name} ne peut pas être construit pour l'architecture actuelle ({arch}) mais "
 "uniquement {suparch}"
 
-#: pikaur/install_cli.py:469
-#, python-brace-format
-msgid "{name} is up to date - skipping"
+#: pikaur/install_cli.py:89
+#, fuzzy, python-brace-format
+msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr "{name} est à jour - ignoré"
 
-#: pikaur/install_cli.py:199
+#: pikaur/install_cli.py:272
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -347,3 +360,36 @@ msgid ""
 msgstr ""
 "{what} dépend de '{dep}'\n"
 " trouvé dans '{location}': '{version}'"
+
+#: pikaur/build.py:306
+msgid "{} does not exist on the filesystem."
+msgstr ""
+
+#~ msgid "Already up-to-date."
+#~ msgstr "Déjà à jour."
+
+#~ msgid "Getting ALL AUR info"
+#~ msgstr "Contenu de l'AUR"
+
+#~ msgid "Installing repository dependencies for {}"
+#~ msgstr "Installation des dépendances du dépôt pour {}"
+
+#~ msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+#~ msgstr ""
+#~ "Le nouveau paquet '{new}' remplace le paquet installé '{installed}'. "
+#~ "Continuer ?"
+
+#~ msgid "Removing already installed dependencies for {}"
+#~ msgstr "Suppression des dépendances déjà installées pour {}"
+
+#~ msgid "Removing make dependencies for {}"
+#~ msgstr "Suppression des dépendances de construction pour {}"
+
+#~ msgid "Starting full system upgrade..."
+#~ msgstr "Démarrage de la mise à jour complète du système…"
+
+#~ msgid "[Y/n]"
+#~ msgstr "[O/n]"
+
+#~ msgid "[y/N]"
+#~ msgstr "[o/N]"

--- a/locale/pt.po
+++ b/locale/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pikaur\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-30 10:46-0300\n"
+"POT-Creation-Date: 2018-04-12 19:10+0100\n"
 "PO-Revision-Date: 2018-03-30 10:47-0300\n"
 "Last-Translator: Alexandre Lopes\n"
 "Language-Team: pt\n"
@@ -28,73 +28,79 @@ msgid_plural "AUR packages will be installed:"
 msgstr[0] "Pacote AUR será instalado:"
 msgstr[1] "Pacotes AUR serão instalados:"
 
-#: pikaur/main.py:148
+#: pikaur/main.py:160
 msgid "Build directory: {}"
 msgstr "Criar diretório: {}"
 
-#: pikaur/install_cli.py:613
+#: pikaur/install_cli.py:678
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "Não é possível criar '{name}'."
 
-#: pikaur/install_cli.py:434
+#: pikaur/install_cli.py:504
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "Não é possível clonar '{name}' em '{path}' do AUR:"
 
-#: pikaur/install_cli.py:436
+#: pikaur/install_cli.py:506
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "Não é possível extrair '{name}' em '{path}' do AUR:"
 
-#: pikaur/prompt.py:94
+#: pikaur/prompt.py:93
 msgid "Command '{}' failed to execute."
 msgstr "O comando '{}' falhou em executar."
 
-#: pikaur/args.py:59
+#: pikaur/args.py:63
 msgid "Common pacman options:"
 msgstr "Opções comuns do pacman:"
 
-#: pikaur/install_cli.py:228
+#: pikaur/install_cli.py:266
 msgid "Dependencies missing for {}"
 msgstr "Dependências ausentes para {}"
 
-#: pikaur/install_cli.py:627
+#: pikaur/install_cli.py:695
 msgid "Dependency cycle detected between {}"
 msgstr "Ciclo de dependência detectado entre {}"
 
-#: pikaur/install_cli.py:170
+#: pikaur/install_cli.py:208
 msgid "Do you want to proceed without editing?"
 msgstr "Você quer continuar sem editar?"
 
-#: pikaur/prompt.py:65
+#: pikaur/prompt.py:72
 msgid "Do you want to proceed?"
 msgstr "Você quer prosseguir?"
 
-#: pikaur/install_cli.py:500
+#: pikaur/install_cli.py:570
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Você quer remover '{installed}'?"
 
-#: pikaur/main.py:151
+#: pikaur/main.py:163
 msgid "Do you want to remove all files?"
 msgstr "Você quer remover todos os arquivos?"
 
-#: pikaur/prompt.py:84
+#: pikaur/prompt.py:97
 msgid "Do you want to retry?"
 msgstr "Você quer tentar de novo?"
 
-#: pikaur/install_cli.py:551
+#: pikaur/install_cli.py:616
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Deseja ver os arquivos de compilação {diff} para o pacote {name}?"
 
-#: pikaur/install_cli.py:517
+#: pikaur/install_cli.py:587
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "Deseja {edit} {file} para o pacote {name}?"
 
-#: pikaur/install_cli.py:146
+#: pikaur/build.py:204
+msgid "Downloading the latest sources for a devel package {}"
+msgid_plural "Downloading the latest sources for devel packages {}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pikaur/install_cli.py:174
 msgid "Failed to build following packages:"
 msgstr "Falha ao criar os seguintes pacotes:"
 
@@ -102,15 +108,11 @@ msgstr "Falha ao criar os seguintes pacotes:"
 msgid "Following packages cannot be found in AUR:"
 msgstr "Os seguintes pacotes não podem ser encontrados no AUR:"
 
-#: pikaur/aur.py:179
-msgid "Getting ALL AUR info"
-msgstr "Obtendo todas as informações do AUR"
-
-#: pikaur/install_cli.py:70
+#: pikaur/install_cli.py:69
 msgid "Ignoring package {}"
 msgstr "Ignorando o pacote {}"
 
-#: pikaur/build.py:326
+#: pikaur/build.py:256
 msgid "Installing already built dependencies for {}"
 msgstr "Instalando dependências já construídas para {}"
 
@@ -120,39 +122,39 @@ msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Nova dependência será instalada a partir do AUR:"
 msgstr[1] "Novas dependências serão instaladas a partir do AUR:"
 
-#: pikaur/install_cli.py:495
+#: pikaur/install_cli.py:565
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr "O novo pacote '{new}' está em conflito com o '{installed}' instalado."
 
-#: pikaur/install_cli.py:487
+#: pikaur/install_cli.py:555
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Novos pacotes '{new}' e '{other}' estão em conflito."
 
-#: pikaur/install_cli.py:214
+#: pikaur/install_cli.py:255
 msgid "Nothing to do."
 msgstr "Nada para fazer."
 
-#: pikaur/args.py:76
+#: pikaur/args.py:81
 msgid "Pikaur-specific options:"
 msgstr "Opções específicas do Pikaur:"
 
-#: pikaur/install_cli.py:389
+#: pikaur/install_cli.py:440
 msgid "Proceed with installation? [Y/n] "
 msgstr "Continuar com a instalação? [Y/n] "
 
-#: pikaur/package_update.py:94
+#: pikaur/package_update.py:99
 msgid "Reading AUR package info..."
 msgid_plural "Reading AUR packages info..."
 msgstr[0] "Lendo informações do pacote AUR..."
 msgstr[1] "Lendo informações dos pacotes AUR ..."
 
-#: pikaur/pacman.py:167
+#: pikaur/pacman.py:148
 msgid "Reading local package database..."
 msgstr "Lendo o banco de dados de pacotes local..."
 
-#: pikaur/pacman.py:211
+#: pikaur/pacman.py:192
 msgid "Reading repository package databases..."
 msgstr "Lendo bancos de dados de pacotes do repositório..."
 
@@ -162,26 +164,26 @@ msgid_plural "Repository packages will be installed:"
 msgstr[0] "O pacote do repositório será instalado:"
 msgstr[1] "Pacotes de repositório serão instalados:"
 
-#: pikaur/install_cli.py:220
+#: pikaur/install_cli.py:356
 msgid "Resolving AUR dependencies..."
 msgstr "Resolvendo dependências do AUR..."
 
-#: pikaur/install_cli.py:702
+#: pikaur/install_cli.py:772
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Revertendo a transação {target}..."
 
-#: pikaur/search_cli.py:145
+#: pikaur/search_cli.py:172
 #, python-brace-format
 msgid "Searching... [{bar}]"
 msgstr "Procurando... [{bar}]"
 
-#: pikaur/install_cli.py:509
+#: pikaur/install_cli.py:579
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Ignorando a revisão de {file} para o pacote {name} ({flag})"
 
-#: pikaur/main.py:112
+#: pikaur/main.py:108
 msgid "Starting full AUR upgrade..."
 msgstr "Iniciando a atualização completa do AUR..."
 
@@ -191,140 +193,161 @@ msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "O pacote de repositórios de terceiros será instalado:"
 msgstr[1] "Pacotes de repositórios de terceiros serão instalados:"
 
-#: pikaur/install_cli.py:449
+#: pikaur/install_cli.py:520
 msgid "Try recovering?"
 msgstr "Tente recuperar?"
 
-#: pikaur/install_cli.py:233
+#: pikaur/install_cli.py:271
 msgid "Version mismatch:"
 msgstr "Incompatibilidade de versão:"
 
-#: pikaur/prompt.py:68
+#: pikaur/prompt.py:77
+#, fuzzy
+msgid "[N]o (--noconfirm)"
+msgstr "[Y]es (--noconfirm)"
+
+#: pikaur/prompt.py:77
 msgid "[Y]es (--noconfirm)"
 msgstr "[Y]es (--noconfirm)"
 
-#: pikaur/install_cli.py:454
+#: pikaur/install_cli.py:525
 msgid "[a] abort"
 msgstr "[a] abortar"
 
-#: pikaur/install_cli.py:450
+#: pikaur/install_cli.py:521
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout --'*'"
 
-#: pikaur/search_cli.py:115
+#: pikaur/search_cli.py:130
 #, python-brace-format
 msgid "[installed: {version}]"
 msgstr "[instalado: {version}]"
 
-#: pikaur/search_cli.py:119
+#: pikaur/search_cli.py:134
 msgid "[installed]"
 msgstr "[instalado]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:452
+#: pikaur/install_cli.py:523
 msgid "[r] remove dir and clone again"
 msgstr "[r] remova o dir e clone novamente"
 
-#: pikaur/install_cli.py:453
+#: pikaur/install_cli.py:524
 msgid "[s] skip this package"
 msgstr "[s] pule este pacote"
 
-#: pikaur/install_cli.py:391
+#: pikaur/install_cli.py:442
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[v]er detalhe do pacote   selecionar pacotes [m]anualmente"
 
-#: pikaur/install_cli.py:445
+#: pikaur/install_cli.py:516
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:459
+#: pikaur/install_cli.py:530
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:552
+#: pikaur/install_cli.py:617
 msgid "diff"
 msgstr "diff"
 
-#: pikaur/args.py:69
+#: pikaur/args.py:73
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "não solicite a edição de PKGBUILDs e outros arquivos de compilação"
 
-#: pikaur/install_cli.py:518
+#: pikaur/args.py:76
+msgid "don't remove build dir after the build"
+msgstr ""
+
+#: pikaur/main.py:247
+msgid "don't run me as root."
+msgstr ""
+
+#: pikaur/install_cli.py:588
 msgid "edit"
 msgstr "editar"
 
-#: pikaur/install_cli.py:626
+#: pikaur/install_cli.py:694
 msgid "error:"
 msgstr "erro:"
 
-#: pikaur/install_cli.py:476
+#: pikaur/install_cli.py:544
 msgid "looking for conflicting packages..."
 msgstr "procurando pacotes conflitantes..."
 
-#: pikaur/install_cli.py:410
+#: pikaur/install_cli.py:461
 msgid "m"
 msgstr "m"
 
-#: pikaur/install_cli.py:167
+#: pikaur/prompt.py:14
+msgid "n"
+msgstr ""
+
+#: pikaur/install_cli.py:205
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr "nenhum editor encontrado. Tente definir $VISUAL ou $EDITOR."
 
-#: pikaur/main.py:234
+#: pikaur/search_cli.py:151
+msgid "outofdate"
+msgstr ""
+
+#: pikaur/main.py:254
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr ""
 "pikaur requer systemd >= 235 (usuários dinâmicos) para ser executado como "
 "root."
 
-#: pikaur/args.py:64
+#: pikaur/args.py:68
 msgid "query packages from AUR only"
 msgstr "pacotes de consulta apenas do AUR"
 
-#: pikaur/args.py:65
+#: pikaur/args.py:69
 msgid "query packages from repository only"
 msgstr "pacotes de consulta apenas do repositório"
 
-#: pikaur/install_cli.py:461
+#: pikaur/install_cli.py:532
 msgid "r"
 msgstr "r"
 
-#: pikaur/install_cli.py:463
+#: pikaur/install_cli.py:534
 msgid "s"
 msgstr "s"
 
-#: pikaur/args.py:70
+#: pikaur/args.py:74
 msgid "search only in package names"
 msgstr "pesquisar apenas em nomes de pacotes"
 
-#: pikaur/args.py:71
+#: pikaur/args.py:75
 msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr ""
 "sysupgrade '-git' e outros pacotes de desenvolvimento com mais de 1 dia"
 
-#: pikaur/install_cli.py:408
+#: pikaur/install_cli.py:459
 msgid "v"
 msgstr "v"
 
-#: pikaur/pprint.py:68 pikaur/install_cli.py:494 pikaur/install_cli.py:542
+#: pikaur/install_cli.py:88 pikaur/install_cli.py:564 pikaur/pprint.py:68
 msgid "warning:"
 msgstr "atenção:"
 
-#: pikaur/install_cli.py:406
+#: pikaur/prompt.py:13 pikaur/install_cli.py:457
 msgid "y"
 msgstr "y"
 
-#: pikaur/install_cli.py:543
-#, python-brace-format
-msgid "{name} AUR repository is up to date - skipping"
-msgstr "{name} O repositório AUR está atualizado - ignorando"
-
-#: pikaur/install_cli.py:585
+#: pikaur/install_cli.py:650
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
 msgstr ""
 "{name} não pode ser criado no arco atual ({arch}). Suportado: {suparch}"
 
-#: pikaur/install_cli.py:234
+#: pikaur/install_cli.py:89
+#, fuzzy, python-brace-format
+msgid "{name} {version} {package_source} package is up to date - skipping"
+msgstr "{name} O repositório AUR está atualizado - ignorando"
+
+#: pikaur/install_cli.py:272
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -333,6 +356,9 @@ msgstr ""
 "{what} depende de: '{dep}'\n"
 "  encontrado em '{location}': '{version}'"
 
-#: pikaur/build.py:375
+#: pikaur/build.py:306
 msgid "{} does not exist on the filesystem."
 msgstr "{} não existe no sistema de arquivos."
+
+#~ msgid "Getting ALL AUR info"
+#~ msgstr "Obtendo todas as informações do AUR"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-09 00:25+0300\n"
+"POT-Creation-Date: 2018-04-12 19:10+0100\n"
 "PO-Revision-Date: 2018-03-09 20:31+0300\n"
 "Last-Translator: Mauladen <twertrue@yandex.ru>\n"
 "Language-Team: none\n"
@@ -18,328 +18,341 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: pikaur/pprint.py:168
+#: pikaur/pprint.py:105
+msgid "({} days old)"
+msgstr ""
+
+#: pikaur/pprint.py:193
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "Будет установлен пакет из AUR:"
 msgstr[1] "Будут установлены пакеты из AUR:"
 
-#: pikaur/main.py:106
-msgid "Already up-to-date."
-msgstr "Уже обновлено."
-
-#: pikaur/main.py:136
+#: pikaur/main.py:160
 msgid "Build directory: {}"
 msgstr "Директория для сборки: {}"
 
-#: pikaur/install_cli.py:534
+#: pikaur/install_cli.py:678
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "Невозможно собрать '{name}'."
 
-#: pikaur/install_cli.py:333
+#: pikaur/install_cli.py:504
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "Невозможно клонировать пакет '{name}' из AUR по пути '{path}':"
 
-#: pikaur/install_cli.py:335
+#: pikaur/install_cli.py:506
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "Невозможно обновить пакет '{name}' из AUR по пути '{path}':"
 
-#: pikaur/prompt.py:39
+#: pikaur/prompt.py:93
 msgid "Command '{}' failed to execute."
 msgstr "Не удалось выполнить команду '{}'."
 
-#: pikaur/main.py:160
+#: pikaur/args.py:63
 msgid "Common pacman options:"
 msgstr "Стандартные параметры pacman:"
 
-#: pikaur/install_cli.py:195
+#: pikaur/install_cli.py:266
 msgid "Dependencies missing for {}"
 msgstr "Отсутствуют зависимости для {}"
 
-#: pikaur/install_cli.py:546
+#: pikaur/install_cli.py:695
 msgid "Dependency cycle detected between {}"
 msgstr "Обнаружена циклическая зависимость между {}"
 
-#: pikaur/install_cli.py:58
+#: pikaur/install_cli.py:208
 msgid "Do you want to proceed without editing?"
 msgstr "Хотите ли вы продолжить без редактирования?"
 
-#: pikaur/prompt.py:8
+#: pikaur/prompt.py:72
 msgid "Do you want to proceed?"
 msgstr "Хотите ли вы продолжить?"
 
-#: pikaur/install_cli.py:395
+#: pikaur/install_cli.py:570
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Вы действительно хотите удалить '{installed}'?"
 
-#: pikaur/main.py:139
+#: pikaur/main.py:163
 msgid "Do you want to remove all files?"
 msgstr "Вы действительно хотите удалить все файлы?"
 
-#: pikaur/prompt.py:29
+#: pikaur/prompt.py:97
 msgid "Do you want to retry?"
 msgstr "Хотите ли вы попробовать снова?"
 
-#: pikaur/install_cli.py:475
+#: pikaur/install_cli.py:616
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Хотите ли вы просмотреть {diff} файлов сборки для пакета {name}?"
 
-#: pikaur/install_cli.py:446
+#: pikaur/install_cli.py:587
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "Хотите ли вы {edit} {file} из пакета {name}?"
 
-#: pikaur/install_cli.py:151
+#: pikaur/build.py:204
+msgid "Downloading the latest sources for a devel package {}"
+msgid_plural "Downloading the latest sources for devel packages {}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pikaur/install_cli.py:174
 msgid "Failed to build following packages:"
 msgstr "Не удалось собрать данные пакеты:"
 
-#: pikaur/pprint.py:64
+#: pikaur/pprint.py:69
 msgid "Following packages cannot be found in AUR:"
 msgstr "Данные пакеты не могут быть найдены в AUR:"
 
-#: pikaur/aur.py:310
-msgid "Getting ALL AUR info"
-msgstr "Получение всех данных из AUR"
-
-#: pikaur/install_cli.py:167
+#: pikaur/install_cli.py:69
 msgid "Ignoring package {}"
 msgstr "Пакет {} был проигнорирован"
 
-#: pikaur/build.py:244
+#: pikaur/build.py:256
 msgid "Installing already built dependencies for {}"
 msgstr "Установка уже собранных зависимостей для {}"
 
-#: pikaur/build.py:277
-msgid "Installing repository dependencies for {}"
-msgstr "Установка зависимостей из репозиториев для {}"
-
-#: pikaur/pprint.py:178
+#: pikaur/pprint.py:204
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Будет установлена новая зависимость из AUR:"
 msgstr[1] "Будут установлены новые зависимости из AUR:"
 
-#: pikaur/install_cli.py:390
+#: pikaur/install_cli.py:565
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr "Новый пакет '{new}' конфликтует с установленным '{installed}'."
 
-#: pikaur/install_cli.py:425
-#, python-brace-format
-msgid "New package '{new}' replaces installed '{installed}' Proceed?"
-msgstr "Новый пакет '{new}' заменяет установленный '{installed}' Продолжить?"
-
-#: pikaur/install_cli.py:382
+#: pikaur/install_cli.py:555
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Новые пакеты '{new}' и '{other}' конфликтуют."
 
-#: pikaur/install_cli.py:116
+#: pikaur/install_cli.py:255
 msgid "Nothing to do."
 msgstr "Нечего делать."
 
-#: pikaur/main.py:169
+#: pikaur/args.py:81
 msgid "Pikaur-specific options:"
 msgstr "Опции pikaur:"
 
-#: pikaur/install_cli.py:286
-msgid "Proceed with installation? [Y/n]"
+#: pikaur/install_cli.py:440
+#, fuzzy
+msgid "Proceed with installation? [Y/n] "
 msgstr "Продолжить установку? [Y/n]"
 
-#: pikaur/package_update.py:45
+#: pikaur/package_update.py:99
 msgid "Reading AUR package info..."
 msgid_plural "Reading AUR packages info..."
 msgstr[0] "Чтение информации о пакете из AUR..."
 msgstr[1] "Чтение информации о пакетах из AUR..."
 
-#: pikaur/pacman.py:167
+#: pikaur/pacman.py:148
 msgid "Reading local package database..."
 msgstr "Чтение локальной базы данных пакетов..."
 
-#: pikaur/pacman.py:201
+#: pikaur/pacman.py:192
 msgid "Reading repository package databases..."
 msgstr "Чтение баз данных пакетов из репозиториев..."
 
-#: pikaur/build.py:383
-msgid "Removing already installed dependencies for {}"
-msgstr "Удаление уже установленных зависимостей {}"
-
-#: pikaur/build.py:304
-msgid "Removing make dependencies for {}"
-msgstr "Удаление зависимостей для сборки {}"
-
-#: pikaur/pprint.py:148
+#: pikaur/pprint.py:170
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "Будет установлен следующий пакет из репозиториев:"
 msgstr[1] "Будут установлены следующие пакеты из репозиториев:"
 
-#: pikaur/install_cli.py:617
+#: pikaur/install_cli.py:356
+#, fuzzy
+msgid "Resolving AUR dependencies..."
+msgstr "разрешение зависимостей..."
+
+#: pikaur/install_cli.py:772
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Откат транзакции {target}..."
 
-#: pikaur/search_cli.py:135
+#: pikaur/search_cli.py:172
 #, python-brace-format
 msgid "Searching... [{bar}]"
 msgstr "Поиск... [{bar}]"
 
-#: pikaur/install_cli.py:438
+#: pikaur/install_cli.py:579
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Пропуск проверки файла {file} для пакета {name} ({flag})"
 
-#: pikaur/main.py:81
+#: pikaur/main.py:108
 msgid "Starting full AUR upgrade..."
 msgstr "Запуск полного обновления пакетов из AUR..."
 
-#: pikaur/main.py:72
-msgid "Starting full system upgrade..."
-msgstr "Запуск полного обновления системы..."
-
-#: pikaur/pprint.py:158
+#: pikaur/pprint.py:182
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Будет установлен следующий пакет из неофициальных репозиториев:"
 msgstr[1] "Будут установлены следующие пакеты из неофициальных репозиториев:"
 
 # This can probably have better translation, but I didn't find any
-#: pikaur/install_cli.py:345
+#: pikaur/install_cli.py:520
 msgid "Try recovering?"
 msgstr "Попробовать восстановить?"
 
-#: pikaur/install_cli.py:200
+#: pikaur/install_cli.py:271
 msgid "Version mismatch:"
 msgstr "Несовпадение версии:"
 
-#: pikaur/prompt.py:12
-msgid "[Y/n]"
-msgstr "[Y/n]"
+#: pikaur/prompt.py:77
+#, fuzzy
+msgid "[N]o (--noconfirm)"
+msgstr "[Y]es (--noconfirm)"
 
-#: pikaur/prompt.py:10
+#: pikaur/prompt.py:77
 msgid "[Y]es (--noconfirm)"
 msgstr "[Y]es (--noconfirm)"
 
-#: pikaur/install_cli.py:350
+#: pikaur/install_cli.py:525
 msgid "[a] abort"
 msgstr "[a] отмена"
 
-#: pikaur/install_cli.py:346
+#: pikaur/install_cli.py:521
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
-#: pikaur/search_cli.py:105
+#: pikaur/search_cli.py:130
 #, python-brace-format
 msgid "[installed: {version}]"
 msgstr "[установлен: {version}]"
 
-#: pikaur/search_cli.py:109
+#: pikaur/search_cli.py:134
 msgid "[installed]"
 msgstr "[установлен]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:348
+#: pikaur/install_cli.py:523
 msgid "[r] remove dir and clone again"
 msgstr "[r] удалить директорию и клонировать заново"
 
-#: pikaur/install_cli.py:349
+#: pikaur/install_cli.py:524
 msgid "[s] skip this package"
 msgstr "[s] пропустить этот пакет"
 
-#: pikaur/install_cli.py:288
+#: pikaur/install_cli.py:442
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[v] просмотреть описания пакетов   [m] вручную выбрать пакеты"
 
-#: pikaur/prompt.py:12
-msgid "[y/N]"
-msgstr "[y/N]"
-
-#: pikaur/install_cli.py:341
+#: pikaur/install_cli.py:516
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:353
+#: pikaur/install_cli.py:530
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:476
+#: pikaur/install_cli.py:617
 msgid "diff"
 msgstr "различия"
 
-#: pikaur/main.py:163
+#: pikaur/args.py:73
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "не запрашивать редактирование файлов PKGBUILD и других файлов сборки"
 
-#: pikaur/install_cli.py:447
+#: pikaur/args.py:76
+msgid "don't remove build dir after the build"
+msgstr ""
+
+#: pikaur/main.py:247
+msgid "don't run me as root."
+msgstr ""
+
+#: pikaur/install_cli.py:588
 msgid "edit"
 msgstr "отредактировать"
 
-#: pikaur/install_cli.py:545
+#: pikaur/install_cli.py:694
 msgid "error:"
 msgstr "ошибка:"
 
-#: pikaur/install_cli.py:369
+#: pikaur/install_cli.py:544
 msgid "looking for conflicting packages..."
 msgstr "поиск конфликтующих пакетов..."
 
-#: pikaur/install_cli.py:305
+#: pikaur/install_cli.py:461
 msgid "m"
 msgstr "m"
 
-#: pikaur/install_cli.py:55
+#: pikaur/prompt.py:14
+msgid "n"
+msgstr ""
+
+#: pikaur/install_cli.py:205
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
-msgstr "редактор не найден. Попробуйте установить переменную окружения $VISUAL или $EDITOR."
+msgstr ""
+"редактор не найден. Попробуйте установить переменную окружения $VISUAL или "
+"$EDITOR."
 
-#: pikaur/main.py:244
+#: pikaur/search_cli.py:151
+msgid "outofdate"
+msgstr ""
+
+#: pikaur/main.py:254
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
-msgstr "pikaur требует systemd >= 235 (поддержка динамических пользователей) для запуска от root."
+msgstr ""
+"pikaur требует systemd >= 235 (поддержка динамических пользователей) для "
+"запуска от root."
 
-#: pikaur/install_cli.py:355
+#: pikaur/args.py:68
+msgid "query packages from AUR only"
+msgstr ""
+
+#: pikaur/args.py:69
+msgid "query packages from repository only"
+msgstr ""
+
+#: pikaur/install_cli.py:532
 msgid "r"
 msgstr "r"
 
-#: pikaur/install_cli.py:183
-msgid "resolving dependencies..."
-msgstr "разрешение зависимостей..."
-
-#: pikaur/install_cli.py:357
+#: pikaur/install_cli.py:534
 msgid "s"
 msgstr "s"
 
-#: pikaur/main.py:164
+#: pikaur/args.py:74
 msgid "search only in package names"
 msgstr "искать только в именах пакетов"
 
-#: pikaur/install_cli.py:303
+#: pikaur/args.py:75
+msgid "sysupgrade '-git' and other dev packages older than 1 day"
+msgstr ""
+
+#: pikaur/install_cli.py:459
 msgid "v"
 msgstr "v"
 
-#: pikaur/pprint.py:63 pikaur/install_cli.py:389 pikaur/install_cli.py:470
+#: pikaur/install_cli.py:88 pikaur/install_cli.py:564 pikaur/pprint.py:68
 msgid "warning:"
 msgstr "внимание:"
 
-#: pikaur/prompt.py:14 pikaur/prompt.py:17 pikaur/install_cli.py:301
+#: pikaur/prompt.py:13 pikaur/install_cli.py:457
 msgid "y"
 msgstr "y"
 
-#: pikaur/install_cli.py:507
+#: pikaur/install_cli.py:650
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
 msgstr ""
-"{name} не может быть собран на текущей архитектуре ({arch}). Поддерживаемые архитектуры: {suparch}"
+"{name} не может быть собран на текущей архитектуре ({arch}). Поддерживаемые "
+"архитектуры: {suparch}"
 
-#: pikaur/install_cli.py:471
-#, python-brace-format
-msgid "{name} is up to date - skipping"
+#: pikaur/install_cli.py:89
+#, fuzzy, python-brace-format
+msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr "{name} уже обновлён - пропуск"
 
-#: pikaur/install_cli.py:201
+#: pikaur/install_cli.py:272
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -347,3 +360,35 @@ msgid ""
 msgstr ""
 "{what} зависит от: '{dep}'\n"
 " найдено в '{location}': '{version}'"
+
+#: pikaur/build.py:306
+msgid "{} does not exist on the filesystem."
+msgstr ""
+
+#~ msgid "Already up-to-date."
+#~ msgstr "Уже обновлено."
+
+#~ msgid "Getting ALL AUR info"
+#~ msgstr "Получение всех данных из AUR"
+
+#~ msgid "Installing repository dependencies for {}"
+#~ msgstr "Установка зависимостей из репозиториев для {}"
+
+#~ msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+#~ msgstr ""
+#~ "Новый пакет '{new}' заменяет установленный '{installed}' Продолжить?"
+
+#~ msgid "Removing already installed dependencies for {}"
+#~ msgstr "Удаление уже установленных зависимостей {}"
+
+#~ msgid "Removing make dependencies for {}"
+#~ msgstr "Удаление зависимостей для сборки {}"
+
+#~ msgid "Starting full system upgrade..."
+#~ msgstr "Запуск полного обновления системы..."
+
+#~ msgid "[Y/n]"
+#~ msgstr "[Y/n]"
+
+#~ msgid "[y/N]"
+#~ msgstr "[y/N]"

--- a/pikaur/search_cli.py
+++ b/pikaur/search_cli.py
@@ -1,10 +1,12 @@
 import sys
+from datetime import datetime
 from multiprocessing.pool import ThreadPool
 from typing import Any, Dict, Tuple, List, Iterable, Union
 
 import pyalpm
 
 from .i18n import _
+from .config import PikaurConfig
 from .core import DataType, PackageSource, return_exception
 from .pprint import color_line, bold_line, format_paragraph, pretty_format_repo_name
 from .pacman import PackageDB
@@ -138,10 +140,22 @@ def print_package_search_results(
                     package.popularity
                 ), 3)
 
+            color_config = PikaurConfig().colors
+            version_color: int = color_config.get('Version')  # type: ignore
+            version = package.version
+
+            if getattr(package, "outofdate", None) is not None:
+                version_color: int = color_config.get('VersionDiffOld')  # type: ignore
+                version = "{} [{}: {}]".format(
+                    package.version,
+                    _("outofdate"),
+                    datetime.fromtimestamp(package.outofdate).strftime('%Y/%m/%d')
+                )
+
             print("{}{} {} {}{}{}".format(
                 repo,
                 bold_line(pkg_name),
-                color_line(package.version, 10),
+                color_line(version, version_color),
                 groups,
                 installed,
                 rating


### PR DESCRIPTION
When a package is out of date, append "[outofdate: since]" where since
is the time it was flagged as out of date.

Respect the version config values: "version" for normal versions and
"VersionDiffOld" for out of date versions.

![image](https://user-images.githubusercontent.com/16593899/38696189-5c8fbece-3e86-11e8-8851-1b8d44d37c61.png)

fixes #124 