### PR TITLE
Translated short keys working is corrected

### DIFF
--- a/locale/tr.po
+++ b/locale/tr.po
@@ -246,7 +246,7 @@ msgstr "[a] bu paketi atla"
 
 #: pikaur/install_cli.py:449
 msgid "[v]iew package detail   [m]anually select packages"
-msgstr "paket detaylarını [g]öster   paketleri [e]lle seç"
+msgstr "paket detaylarını [g]öster   paketleri elle se[ç]"
 
 #: pikaur/install_cli.py:526
 msgid "a"
@@ -282,7 +282,7 @@ msgstr "çakışan paketlere bakılıyor..."
 
 #: pikaur/install_cli.py:468
 msgid "m"
-msgstr "e"
+msgstr "ç"
 
 #: pikaur/prompt.py:15
 msgid "n"

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -448,7 +448,7 @@ class InstallPackagesCLI():
                 color_line('::', 12),
                 bold_line(_('[v]iew package detail   [m]anually select packages')))
 
-            answer = get_input(prompt,  _('y').upper() + _('n') + _('v') + _('m'))
+            answer = get_input(prompt, _('y').upper() + _('n') + _('v') + _('m'))
 
             return answer
 

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -448,7 +448,7 @@ class InstallPackagesCLI():
                 color_line('::', 12),
                 bold_line(_('[v]iew package detail   [m]anually select packages')))
 
-            answer = get_input(prompt, 'Ynvm')
+            answer = get_input(prompt,  _('y').upper() + _('n') + _('v') + _('m'))
 
             return answer
 
@@ -534,7 +534,7 @@ class InstallPackagesCLI():
                         _("[s] skip this package"),
                         _("[a] abort"))
 
-                    answer = get_input(prompt, 'crsA')
+                    answer = get_input(prompt, _('c') + _('r') + _('s') + _('a').upper())
 
                 answer = answer.lower()[0]
                 if answer == _("c"):


### PR DESCRIPTION
1. When I am using "requireenterconfirm = no" in config, translated short keys not working correctly, every time application turns with error code 125. After this patch working is corrected.
2. Turkish translation file had a short keys conflict, it has been corrected.