### PR TITLE
fix(aur): remove req.set_proxy to fix 404 error

### DIFF
--- a/pikaur/aur.py
+++ b/pikaur/aur.py
@@ -1,4 +1,3 @@
-import os
 import gzip
 import json
 from multiprocessing.pool import ThreadPool

--- a/pikaur/aur.py
+++ b/pikaur/aur.py
@@ -50,21 +50,6 @@ class AURPackageInfo(DataType):
 
 def read_bytes_from_url(url: str) -> bytes:
     req = request.Request(url)
-    last_proxy_params: Tuple[str, str] = None
-    for proxy_env_var in ('http_proxy', 'https_proxy'):
-        if proxy_env_var not in os.environ:
-            continue
-        try:
-            proxy_url = parse.urlparse(os.environ[proxy_env_var])
-        except Exception:
-            pass
-        else:
-            last_proxy_params = (
-                proxy_url.netloc or proxy_url.path,
-                proxy_url.scheme or proxy_env_var.split('_')[0]
-            )
-    if last_proxy_params:
-        req.set_proxy(*last_proxy_params)
     response = request.urlopen(req)
     result_bytes = response.read()
     return result_bytes


### PR DESCRIPTION
When `req.set_proxy` is used, installing an AUR package results in a 404 error (same message as #132).

Python's urllib [already uses](https://docs.python.org/3/howto/urllib2.html#proxies) the proxy from environment variables by default. The extra `req.set_proxy` breaks the request state.

With auto-detected proxy, the target host is set to the proxy server e.g. `127.0.0.1:8123`. The original target host `aur.archlinux.org` is moved to the "tunneled" host, and sent to the target using HTTP CONNECT method. Some HTTP logs are shown below:
```
CONNECT aur.archlinux.org:443 HTTP/1.0

GET /rpc/?v=5&type=info&arg[]=pikaur HTTP/1.1
Host: aur.archlinux.org
```

With the extra `req.set_proxy`, the target is set to `127.0.0.1:8123` again, but the current target host `127.0.0.1:8123` is moved to the tunneled host:
```
CONNECT aur.archlinux.org:443 HTTP/1.0

GET /rpc/?v=5&type=info&arg[]=pikaur HTTP/1.1
Host: 127.0.0.1:8123
```

This causes that the server sees the host as `127.0.0.1:8123`. There are many websites on that AUR server, and without valid host information, the server uses `bbs.archlinux.org` by default:
```
HTTP/1.1 301 Moved Permanently

CONNECT bbs.archlinux.org:443 HTTP/1.0

GET /rpc/?v=5&type=info&arg[]=pikaur HTTP/1.1
Host: bbs.archlinux.org

HTTP/1.1 404 Not Found
```

This effect can also be seen by changing the URL to `https://aur.archlinux.org/viewforum.php?id=23`. The request accidentally succeeds with `set_proxy` because this is an valid URL under the BBS website.

Removing `req.set_proxy` fixes the 404 error for me and still uses the proxy.

