### PR TITLE
added config to hide prompt to show build files diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ don't remove `~/.cache/pikaur/build/${PACKAGE_NAME}` directory between the build
 ##### NoEdit (default: no)
 don't prompt to edit PKGBUILD and install files.
 
+##### NoDiff (default: no)
+don't prompt to show the build files diff.
 
 #### [colors]
 

--- a/locale/da.po
+++ b/locale/da.po
@@ -7,38 +7,38 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-17 13:26+0000\n"
+"POT-Creation-Date: 2018-04-24 21:14+0200\n"
 "PO-Revision-Date: 2018-04-20 01:17+0200\n"
+"Last-Translator: \n"
 "Language-Team: none\n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.6\n"
-"Last-Translator: \n"
-"Language: da\n"
 
-#: pikaur/pprint.py:124
+#: pikaur/pprint.py:153
 msgid "({} days old)"
 msgstr "({} dage gammelt)"
 
-#: pikaur/pprint.py:212
+#: pikaur/pprint.py:241
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "AUR pakke som vil blive installeret:"
 msgstr[1] "AUR pakker som vil blive installeret:"
 
-#: pikaur/install_cli.py:682
+#: pikaur/install_cli.py:736
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "Kan ikke bygge '{name}'."
 
-#: pikaur/install_cli.py:506
+#: pikaur/install_cli.py:542
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "Kan ikke klone '{name}' i '{path}' fra AUR:"
 
-#: pikaur/install_cli.py:508
+#: pikaur/install_cli.py:544
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "Kan ikke hente '{name}' i '{path}' fra AUR:"
@@ -51,15 +51,15 @@ msgstr "Kommando '{}' mislykkedes."
 msgid "Common pacman options:"
 msgstr "Fælles pacman muligheder:"
 
-#: pikaur/install_cli.py:266
+#: pikaur/install_cli.py:294
 msgid "Dependencies missing for {}"
 msgstr "Afhængigheder mangler for {}"
 
-#: pikaur/install_cli.py:700
+#: pikaur/install_cli.py:754
 msgid "Dependency cycle detected between {}"
 msgstr "Afhængighedscyklus opdaget mellem {}"
 
-#: pikaur/install_cli.py:208
+#: pikaur/install_cli.py:233
 msgid "Do you want to proceed without editing?"
 msgstr "Vil du fortsætte uden at redigere?"
 
@@ -67,12 +67,12 @@ msgstr "Vil du fortsætte uden at redigere?"
 msgid "Do you want to proceed?"
 msgstr "Vil du fortsætte?"
 
-#: pikaur/install_cli.py:572
+#: pikaur/install_cli.py:610
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Vil du fjerne  '{installed}'?"
 
-#: pikaur/main.py:170
+#: pikaur/main.py:174
 msgid "Do you want to remove all files?"
 msgstr "Vil du fjerne all filer?"
 
@@ -80,71 +80,78 @@ msgstr "Vil du fjerne all filer?"
 msgid "Do you want to retry?"
 msgstr "Vil du prøve igen?"
 
-#: pikaur/install_cli.py:619
+#: pikaur/install_cli.py:687
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Vil du se bygfiler {diff} for pakken {name}"
 
-#: pikaur/install_cli.py:590
+#: pikaur/install_cli.py:644
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "Vil du {edit} {file} for pakken {name}?"
 
-#: pikaur/build.py:199
+#: pikaur/build.py:201
 msgid "Downloading the latest sources for a devel package {}"
 msgid_plural "Downloading the latest sources for devel packages {}"
 msgstr[0] "Henter den nyeste kildekode for devel pakke {}"
 msgstr[1] "Henter den nyeste kildekode for devel pakker{}"
 
-#: pikaur/install_cli.py:174
+#: pikaur/install_cli.py:199
 msgid "Failed to build following packages:"
 msgstr "At bygge følgende pakker mislykkedes:"
 
-#: pikaur/build.py:441
+#: pikaur/build.py:442
 msgid "Failed to remove installed dependencies, packages inconsistency: {}"
-msgstr "Det lykkedes ikke at fjerne installerede afhængigheder, inkonsekvens for pakker: {}"
+msgstr ""
+"Det lykkedes ikke at fjerne installerede afhængigheder, inkonsekvens for "
+"pakker: {}"
 
-#: pikaur/pprint.py:88
+#: pikaur/pprint.py:107
 msgid "Following packages cannot be found in AUR:"
 msgstr "Følgende pakker kunne ikke findes i  AUR:"
 
-#: pikaur/install_cli.py:69
+#: pikaur/install_cli.py:72
 msgid "Ignoring package {}"
 msgstr "Ignorer pakken {}"
 
-#: pikaur/build.py:261
+#: pikaur/build.py:277
 msgid "Installing already built dependencies for {}"
 msgstr "Installere allerede bygget afhængigheder for {}"
 
-#: pikaur/build.py:409
+#: pikaur/build.py:418
 msgid "Installing repository dependencies for {}"
 msgstr "installere repository afhængigheder for {}"
 
-#: pikaur/pprint.py:223
+#: pikaur/pprint.py:252
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Ny afhængighed vil blive installeret fra AUR:"
 msgstr[1] "Nye afhængigheder vil blive installeret fra AUR:"
 
-#: pikaur/install_cli.py:567
+#: pikaur/install_cli.py:605
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr "Ny pakke '{new}' konflikter med installeret pakke '{installed}'."
 
-#: pikaur/install_cli.py:557
+#: pikaur/install_cli.py:622
+#, fuzzy, python-brace-format
+msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+msgstr "Ny pakke '{new}' konflikter med installeret pakke '{installed}'."
+
+#: pikaur/install_cli.py:593
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Nye pakker '{new}' og '{other}' er i konflikt."
 
-#: pikaur/install_cli.py:255
+#: pikaur/install_cli.py:283
 msgid "Nothing to do."
 msgstr "Ingenting at lave."
 
-#: pikaur/args.py:89
+#: pikaur/args.py:90
 msgid "Pikaur-specific options:"
 msgstr "Pikaur-specifikke muligheder:"
 
-#: pikaur/install_cli.py:442
+#: pikaur/install_cli.py:472
 msgid "Proceed with installation? [Y/n] "
 msgstr "Fortsæt med installationen? [J/n] "
 
@@ -162,21 +169,21 @@ msgstr "Læser lokal pakkedatabase..."
 msgid "Reading repository package databases..."
 msgstr "Læser repository pakkedatabaser ..."
 
-#: pikaur/build.py:451
+#: pikaur/build.py:452
 msgid "Removing installed repository dependencies for {}"
 msgstr "Fjerner installeret repository afhængigheder for {}"
 
-#: pikaur/pprint.py:189
+#: pikaur/pprint.py:218
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "Repository pakke vil blive installeret:"
 msgstr[1] "Repository pakker vil blive installeret:"
 
-#: pikaur/install_cli.py:358
+#: pikaur/install_cli.py:388
 msgid "Resolving AUR dependencies..."
 msgstr "Løser AUR afhængigheder..."
 
-#: pikaur/install_cli.py:777
+#: pikaur/install_cli.py:829
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Gendannelse af {target} transaktionen..."
@@ -186,26 +193,26 @@ msgstr "Gendannelse af {target} transaktionen..."
 msgid "Searching... [{bar}]"
 msgstr "Søger... [{bar}]"
 
-#: pikaur/install_cli.py:582
+#: pikaur/install_cli.py:636
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Springer over gennemgang af {file} til pakken {name} ({flag})"
 
-#: pikaur/main.py:113
+#: pikaur/main.py:116
 msgid "Starting full AUR upgrade..."
 msgstr "Begynder fuld AUR upgradering..."
 
-#: pikaur/pprint.py:201
+#: pikaur/pprint.py:230
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Tredjeparts repository pakke vil blive installeret:"
 msgstr[1] "Tredjeparts repository pakker vil blive installeret:"
 
-#: pikaur/install_cli.py:522
+#: pikaur/install_cli.py:558
 msgid "Try recovering?"
 msgstr "Prøv at gendanne?"
 
-#: pikaur/install_cli.py:271
+#: pikaur/install_cli.py:299
 msgid "Version mismatch:"
 msgstr "Versions uoverensstemmelse:"
 
@@ -217,11 +224,11 @@ msgstr "[N]ej (--noconfirm)"
 msgid "[Y]es (--noconfirm)"
 msgstr "[J]a (--noconfirm)"
 
-#: pikaur/install_cli.py:527
+#: pikaur/install_cli.py:563
 msgid "[a] abort"
 msgstr "[a] afbryd"
 
-#: pikaur/install_cli.py:523
+#: pikaur/install_cli.py:559
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
@@ -235,27 +242,27 @@ msgid "[installed]"
 msgstr "[installeret]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:525
+#: pikaur/install_cli.py:561
 msgid "[r] remove dir and clone again"
 msgstr "[f] fjern mappe og klon igen"
 
-#: pikaur/install_cli.py:526
+#: pikaur/install_cli.py:562
 msgid "[s] skip this package"
 msgstr "[s] spring denne pakke over"
 
-#: pikaur/install_cli.py:444
+#: pikaur/install_cli.py:474
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[s]e pakke detaljer  [m]anuelt vælg pakker"
 
-#: pikaur/install_cli.py:518
+#: pikaur/install_cli.py:554 pikaur/install_cli.py:565
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:532
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:568
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:620
+#: pikaur/install_cli.py:688
 msgid "diff"
 msgstr "forskelle"
 
@@ -263,39 +270,50 @@ msgstr "forskelle"
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "spørg ikke om at redigere PKGBUILDs og andre bygfiler"
 
+#: pikaur/args.py:85
+#, fuzzy
+msgid "don't prompt to show the build files diff"
+msgstr "spørg ikke om at redigere PKGBUILDs og andre bygfiler"
+
 #: pikaur/args.py:84
 msgid "don't remove build dir after the build"
 msgstr "fjern ikke bygmappen efter byg"
 
-#: pikaur/install_cli.py:591
+#: pikaur/install_cli.py:645
 msgid "edit"
 msgstr "rediger"
 
-#: pikaur/install_cli.py:699
+#: pikaur/main.py:266
+#, fuzzy
+msgid "error"
+msgstr "fejl:"
+
+#: pikaur/install_cli.py:753
 msgid "error:"
 msgstr "fejl:"
 
-#: pikaur/install_cli.py:546
+#: pikaur/install_cli.py:582
 msgid "looking for conflicting packages..."
 msgstr "leder efter pakker der konflikter med hinanden..."
 
-#: pikaur/install_cli.py:463
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:493
 msgid "m"
 msgstr "m"
 
-#: pikaur/prompt.py:15
+#: pikaur/prompt.py:15 pikaur/install_cli.py:476
 msgid "n"
 msgstr "n"
 
-#: pikaur/install_cli.py:205
+#: pikaur/install_cli.py:230
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
-msgstr "intet tekstredigeringsprogram fundet. Prøv at sætte $VISUAL eller $EDITOR."
+msgstr ""
+"intet tekstredigeringsprogram fundet. Prøv at sætte $VISUAL eller $EDITOR."
 
 #: pikaur/search_cli.py:154
 msgid "outofdate"
 msgstr "forældet"
 
-#: pikaur/main.py:254
+#: pikaur/main.py:258
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr "pikaur kræver systemd >= 235 (dynamic users) for at køre som root."
 
@@ -307,11 +325,11 @@ msgstr "forespørg kun pakker fra AUR"
 msgid "query packages from repository only"
 msgstr "forespørg kun pakker fra repository"
 
-#: pikaur/install_cli.py:534
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:570
 msgid "r"
 msgstr "f"
 
-#: pikaur/install_cli.py:536
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:572
 msgid "s"
 msgstr "s"
 
@@ -323,29 +341,31 @@ msgstr "søg kun i pakkenavne"
 msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr "sysupgrade '-git' og andre dev pakker ældre end 1 dag"
 
-#: pikaur/install_cli.py:461
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:491
 msgid "v"
 msgstr "s"
 
-#: pikaur/install_cli.py:88 pikaur/install_cli.py:566 pikaur/pprint.py:87
+#: pikaur/install_cli.py:91 pikaur/install_cli.py:604 pikaur/pprint.py:106
 msgid "warning:"
 msgstr "advarsel:"
 
-#: pikaur/install_cli.py:459 pikaur/prompt.py:14
+#: pikaur/prompt.py:14 pikaur/install_cli.py:476 pikaur/install_cli.py:489
 msgid "y"
 msgstr "j"
 
-#: pikaur/install_cli.py:653
+#: pikaur/install_cli.py:114
 #, python-brace-format
-msgid "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
-msgstr "{name} kan ikke bygge på denne arkitektur ({arch}). Understøtted: {suparch}"
+msgid ""
+"{name} can't be built on the current arch ({arch}). Supported: {suparch}"
+msgstr ""
+"{name} kan ikke bygge på denne arkitektur ({arch}). Understøtted: {suparch}"
 
-#: pikaur/install_cli.py:89
+#: pikaur/install_cli.py:92
 #, python-brace-format
 msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr "{name} {version} {package_source} pakken er opdateret - springer over"
 
-#: pikaur/install_cli.py:273
+#: pikaur/install_cli.py:301
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -358,12 +378,12 @@ msgstr ""
 msgid "{} does not exist on the filesystem."
 msgstr "{} eksistere ikke på filsystemet."
 
-#: pikaur/main.py:167
+#: pikaur/main.py:171
 msgid "{}: {}"
 msgstr "{}: {}"
 
-msgid "Build directory: {}"
-msgstr "Bygmappe: {}"
+#~ msgid "Build directory: {}"
+#~ msgstr "Bygmappe: {}"
 
-msgid "don't run me as root."
-msgstr "kør mig ikke som root."
+#~ msgid "don't run me as root."
+#~ msgstr "kør mig ikke som root."

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-17 13:26+0000\n"
-"PO-Revision-Date: 2018-04-15 11:08+0200\n"
+"POT-Creation-Date: 2018-04-24 21:14+0200\n"
+"PO-Revision-Date: 2018-04-24 21:17+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: de\n"
@@ -18,27 +18,27 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: pikaur/pprint.py:124
+#: pikaur/pprint.py:153
 msgid "({} days old)"
 msgstr "({} Tage alt)"
 
-#: pikaur/pprint.py:212
+#: pikaur/pprint.py:241
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "Zu installierendes AUR-Paket:"
 msgstr[1] "Zu installierende AUR-Pakete:"
 
-#: pikaur/install_cli.py:682
+#: pikaur/install_cli.py:736
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "'{name}' kann nicht gebaut werden."
 
-#: pikaur/install_cli.py:506
+#: pikaur/install_cli.py:542
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "'{name}' in '{path}' kann nicht vom AUR geklont werden:"
 
-#: pikaur/install_cli.py:508
+#: pikaur/install_cli.py:544
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "'{name}' in '{path} kann nicht vom AUR bezogen werden:"
@@ -51,15 +51,15 @@ msgstr "Ausführung des Befehls '{}' ist fehlgeschlagen."
 msgid "Common pacman options:"
 msgstr "Allgemeine Pacman-Optionen:"
 
-#: pikaur/install_cli.py:266
+#: pikaur/install_cli.py:294
 msgid "Dependencies missing for {}"
 msgstr "Fehlende Abhängigkeiten für {}"
 
-#: pikaur/install_cli.py:700
+#: pikaur/install_cli.py:754
 msgid "Dependency cycle detected between {}"
 msgstr "Abhängigkeitsschleife entdeckt zwischen {}"
 
-#: pikaur/install_cli.py:208
+#: pikaur/install_cli.py:233
 msgid "Do you want to proceed without editing?"
 msgstr "Ohne editieren fortfahren?"
 
@@ -67,12 +67,12 @@ msgstr "Ohne editieren fortfahren?"
 msgid "Do you want to proceed?"
 msgstr "Fortsetzen?"
 
-#: pikaur/install_cli.py:572
+#: pikaur/install_cli.py:610
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Soll '{installed}' gelöscht werden?"
 
-#: pikaur/main.py:170
+#: pikaur/main.py:174
 msgid "Do you want to remove all files?"
 msgstr "Sollen alle Dateien gelöscht werden?"
 
@@ -80,73 +80,80 @@ msgstr "Sollen alle Dateien gelöscht werden?"
 msgid "Do you want to retry?"
 msgstr "Erneut versuchen?"
 
-#: pikaur/install_cli.py:619
+#: pikaur/install_cli.py:687
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Build-Dateien {diff} für {name} anzeigen?"
 
-#: pikaur/install_cli.py:590
+#: pikaur/install_cli.py:644
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "{edit} {file} für Paket {name}?"
 
-#: pikaur/build.py:199
+#: pikaur/build.py:201
 msgid "Downloading the latest sources for a devel package {}"
 msgid_plural "Downloading the latest sources for devel packages {}"
 msgstr[0] "Download des neusten Sourcecodes für Entwicklerpaket {}"
 msgstr[1] "Download der neusten Sourcecodes für Entwicklerpakete {}"
 
-#: pikaur/install_cli.py:174
+#: pikaur/install_cli.py:199
 msgid "Failed to build following packages:"
 msgstr "Der Bau folgender Pakete ist fehlgeschlagen:"
 
-#: pikaur/build.py:441
+#: pikaur/build.py:442
 msgid "Failed to remove installed dependencies, packages inconsistency: {}"
 msgstr "Konnte die installierte Abhängigkeit nicht entfernen, Inkonsistenz: {}"
 
-#: pikaur/pprint.py:88
+#: pikaur/pprint.py:107
 msgid "Following packages cannot be found in AUR:"
 msgstr "Folgende Pakete können im AUR nicht gefunden werden:"
 
-#: pikaur/install_cli.py:69
+#: pikaur/install_cli.py:72
 msgid "Ignoring package {}"
 msgstr "Ignoriere Paket {}"
 
-#: pikaur/build.py:261
+#: pikaur/build.py:277
 msgid "Installing already built dependencies for {}"
 msgstr "Installiere bereits gebaute Abhängigkeiten für {}"
 
-#: pikaur/build.py:409
+#: pikaur/build.py:418
 msgid "Installing repository dependencies for {}"
 msgstr "Installiere Repository-Abhängigkeiten für {}"
 
-#: pikaur/pprint.py:223
+#: pikaur/pprint.py:252
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Zu installierende Abhängigkeit aus dem AUR:"
 msgstr[1] "Zu installierende Abhängigkeiten aus dem AUR:"
 
-#: pikaur/install_cli.py:567
+#: pikaur/install_cli.py:605
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr ""
 "Neues Paket '{new}' steht in Konflikt mit bereits installiertem Paket "
 "'{installed}'."
 
-#: pikaur/install_cli.py:557
+#: pikaur/install_cli.py:622
+#, fuzzy, python-brace-format
+msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+msgstr ""
+"Neues Paket '{new}' steht in Konflikt mit bereits installiertem Paket "
+"'{installed}'."
+
+#: pikaur/install_cli.py:593
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Neue Pakete '{new}' und '{other}' stehen in Konflikt."
 
-#: pikaur/install_cli.py:255
+#: pikaur/install_cli.py:283
 msgid "Nothing to do."
 msgstr "Nichts zu tun."
 
-#: pikaur/args.py:89
+#: pikaur/args.py:90
 msgid "Pikaur-specific options:"
 msgstr "Pikaur-spezifische Optionen:"
 
-#: pikaur/install_cli.py:442
+#: pikaur/install_cli.py:472
 msgid "Proceed with installation? [Y/n] "
 msgstr "Mit Installation fortfahren? [J/n] "
 
@@ -164,21 +171,21 @@ msgstr "Lese lokale Paketdatenbank..."
 msgid "Reading repository package databases..."
 msgstr "Lese Repository-Paketdatenbank..."
 
-#: pikaur/build.py:451
+#: pikaur/build.py:452
 msgid "Removing installed repository dependencies for {}"
 msgstr "Entferne installierte Repository-Abhängigkeiten für {}"
 
-#: pikaur/pprint.py:189
+#: pikaur/pprint.py:218
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "Zu installierendes Repository-Paket:"
 msgstr[1] "Zu installierende Repository-Pakete:"
 
-#: pikaur/install_cli.py:358
+#: pikaur/install_cli.py:388
 msgid "Resolving AUR dependencies..."
 msgstr "Löse AUR-Abhängigkeiten auf..."
 
-#: pikaur/install_cli.py:777
+#: pikaur/install_cli.py:829
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Mache Transaktion {target} rückgängig..."
@@ -188,26 +195,26 @@ msgstr "Mache Transaktion {target} rückgängig..."
 msgid "Searching... [{bar}]"
 msgstr "Suche... [{bar}]"
 
-#: pikaur/install_cli.py:582
+#: pikaur/install_cli.py:636
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Überspringe Review von {file} für {name} Paket ({flag})"
 
-#: pikaur/main.py:113
+#: pikaur/main.py:116
 msgid "Starting full AUR upgrade..."
 msgstr "Starte komplettes AUR Upgrade..."
 
-#: pikaur/pprint.py:201
+#: pikaur/pprint.py:230
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Zu installierendes 3rd-Party Repository-Paket:"
 msgstr[1] "Zu installierende 3rd-Party Repository-Pakete:"
 
-#: pikaur/install_cli.py:522
+#: pikaur/install_cli.py:558
 msgid "Try recovering?"
 msgstr "Versuchen wiederherzustellen?"
 
-#: pikaur/install_cli.py:271
+#: pikaur/install_cli.py:299
 msgid "Version mismatch:"
 msgstr "Versionskonflikt:"
 
@@ -219,11 +226,11 @@ msgstr "[N]ein (--noconfirm)"
 msgid "[Y]es (--noconfirm)"
 msgstr "[J]a (--noconfirm)"
 
-#: pikaur/install_cli.py:527
+#: pikaur/install_cli.py:563
 msgid "[a] abort"
 msgstr "[a] abbrechen"
 
-#: pikaur/install_cli.py:523
+#: pikaur/install_cli.py:559
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
@@ -237,27 +244,27 @@ msgid "[installed]"
 msgstr "[installiert]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:525
+#: pikaur/install_cli.py:561
 msgid "[r] remove dir and clone again"
 msgstr "[e] entferne Verzeichnis und klone erneut"
 
-#: pikaur/install_cli.py:526
+#: pikaur/install_cli.py:562
 msgid "[s] skip this package"
 msgstr "[u] Paket überspringen"
 
-#: pikaur/install_cli.py:444
+#: pikaur/install_cli.py:474
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[P]aketdetails anzeigen, Pakete [m]anuell auswählen"
 
-#: pikaur/install_cli.py:518
+#: pikaur/install_cli.py:554 pikaur/install_cli.py:565
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:532
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:568
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:620
+#: pikaur/install_cli.py:688
 msgid "diff"
 msgstr "Unterschied"
 
@@ -266,31 +273,41 @@ msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr ""
 "Nicht nachfragen, ob PKGBUILDs und andere Dateien editiert werden sollen"
 
+#: pikaur/args.py:85
+msgid "don't prompt to show the build files diff"
+msgstr ""
+"Nicht nachfragen, ob Unterschiede der Artefakte angezeigt werden sollen"
+
 #: pikaur/args.py:84
 msgid "don't remove build dir after the build"
 msgstr "Build-Verzeichnis nach dem Bauen nicht löschen"
 
-#: pikaur/install_cli.py:591
+#: pikaur/install_cli.py:645
 msgid "edit"
 msgstr "Editiere"
 
-#: pikaur/install_cli.py:699
+#: pikaur/main.py:266
+#, fuzzy
+msgid "error"
+msgstr "Fehler:"
+
+#: pikaur/install_cli.py:753
 msgid "error:"
 msgstr "Fehler:"
 
-#: pikaur/install_cli.py:546
+#: pikaur/install_cli.py:582
 msgid "looking for conflicting packages..."
 msgstr "Suche nach in Konflikt stehenden Pakten..."
 
-#: pikaur/install_cli.py:463
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:493
 msgid "m"
 msgstr "m"
 
-#: pikaur/prompt.py:15
+#: pikaur/prompt.py:15 pikaur/install_cli.py:476
 msgid "n"
 msgstr "n"
 
-#: pikaur/install_cli.py:205
+#: pikaur/install_cli.py:230
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr "Kein Editor gefunden. Versuchen Sie $VISUAL oder $EDITOR zu setzen."
 
@@ -298,7 +315,7 @@ msgstr "Kein Editor gefunden. Versuchen Sie $VISUAL oder $EDITOR zu setzen."
 msgid "outofdate"
 msgstr "veraltet"
 
-#: pikaur/main.py:254
+#: pikaur/main.py:258
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr ""
 "Pikaur benötigt systemd >= 235 (dynamic users) um als root ausgeführt werden "
@@ -312,11 +329,11 @@ msgstr "Nur AUR-Pakete abfragen"
 msgid "query packages from repository only"
 msgstr "Nur Repository-Pakete abfragem"
 
-#: pikaur/install_cli.py:534
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:570
 msgid "r"
 msgstr "e"
 
-#: pikaur/install_cli.py:536
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:572
 msgid "s"
 msgstr "u"
 
@@ -328,19 +345,19 @@ msgstr "Nur in Paketnamen suchen"
 msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr "sysupgrade '-git' und andere dev Pakete älter als 1 Tag"
 
-#: pikaur/install_cli.py:461
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:491
 msgid "v"
 msgstr "p"
 
-#: pikaur/install_cli.py:88 pikaur/install_cli.py:566 pikaur/pprint.py:87
+#: pikaur/install_cli.py:91 pikaur/install_cli.py:604 pikaur/pprint.py:106
 msgid "warning:"
 msgstr "Warnung:"
 
-#: pikaur/install_cli.py:459 pikaur/prompt.py:14
+#: pikaur/prompt.py:14 pikaur/install_cli.py:476 pikaur/install_cli.py:489
 msgid "y"
 msgstr "j"
 
-#: pikaur/install_cli.py:653
+#: pikaur/install_cli.py:114
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
@@ -348,13 +365,13 @@ msgstr ""
 "{name} kann auf der aktuellen Architektur ({arch}) nicht gebaut werden. "
 "Unterstützt wird: {suparch}"
 
-#: pikaur/install_cli.py:89
+#: pikaur/install_cli.py:92
 #, python-brace-format
 msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr ""
 "{name} {version} {package_source} Paket ist aktuell - wird übersprungen"
 
-#: pikaur/install_cli.py:273
+#: pikaur/install_cli.py:301
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -367,7 +384,7 @@ msgstr ""
 msgid "{} does not exist on the filesystem."
 msgstr "{} existiert nicht im Dateisystem."
 
-#: pikaur/main.py:167
+#: pikaur/main.py:171
 msgid "{}: {}"
 msgstr "{}: {}"
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-17 13:26+0000\n"
+"POT-Creation-Date: 2018-04-24 21:14+0200\n"
 "PO-Revision-Date: 2018-03-03 16:29+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,27 +18,27 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: pikaur/pprint.py:124
+#: pikaur/pprint.py:153
 msgid "({} days old)"
 msgstr ""
 
-#: pikaur/pprint.py:212
+#: pikaur/pprint.py:241
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "Le paquet de l'AUR sera installé :"
 msgstr[1] "Les paquets de l'AUR seront installés :"
 
-#: pikaur/install_cli.py:682
+#: pikaur/install_cli.py:736
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "Impossible de construire '{name}'."
 
-#: pikaur/install_cli.py:506
+#: pikaur/install_cli.py:542
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "Impossible de cloner '{name}' dans '{path}' depuis l'AUR :"
 
-#: pikaur/install_cli.py:508
+#: pikaur/install_cli.py:544
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "Impossible de rapatrier '{name}' dans '{path}' depuis l'AUR :"
@@ -51,15 +51,15 @@ msgstr "La commande '{}' a échoué."
 msgid "Common pacman options:"
 msgstr "Options standards de pacman :"
 
-#: pikaur/install_cli.py:266
+#: pikaur/install_cli.py:294
 msgid "Dependencies missing for {}"
 msgstr "Dépendances manquantes pour {}"
 
-#: pikaur/install_cli.py:700
+#: pikaur/install_cli.py:754
 msgid "Dependency cycle detected between {}"
 msgstr "Cycle de dépendances détecté entre {}"
 
-#: pikaur/install_cli.py:208
+#: pikaur/install_cli.py:233
 msgid "Do you want to proceed without editing?"
 msgstr "Continuer sans modifier ?"
 
@@ -67,12 +67,12 @@ msgstr "Continuer sans modifier ?"
 msgid "Do you want to proceed?"
 msgstr "Continuer ?"
 
-#: pikaur/install_cli.py:572
+#: pikaur/install_cli.py:610
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Supprimer '{installed}' ?"
 
-#: pikaur/main.py:170
+#: pikaur/main.py:174
 msgid "Do you want to remove all files?"
 msgstr "Supprimer tous les fichiers ?"
 
@@ -80,73 +80,80 @@ msgstr "Supprimer tous les fichiers ?"
 msgid "Do you want to retry?"
 msgstr "Réessayer ?"
 
-#: pikaur/install_cli.py:619
+#: pikaur/install_cli.py:687
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Visualiser les {diff} des fichiers de build pour le paquet {name} ?"
 
-#: pikaur/install_cli.py:590
+#: pikaur/install_cli.py:644
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "{edit} {file} pour le paquet {name} ?"
 
-#: pikaur/build.py:199
+#: pikaur/build.py:201
 msgid "Downloading the latest sources for a devel package {}"
 msgid_plural "Downloading the latest sources for devel packages {}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pikaur/install_cli.py:174
+#: pikaur/install_cli.py:199
 msgid "Failed to build following packages:"
 msgstr "Impossible de construire les paquets suivants :"
 
-#: pikaur/build.py:441
+#: pikaur/build.py:442
 msgid "Failed to remove installed dependencies, packages inconsistency: {}"
 msgstr ""
 
-#: pikaur/pprint.py:88
+#: pikaur/pprint.py:107
 msgid "Following packages cannot be found in AUR:"
 msgstr "Les paquets suivants sont introuvables dans l'AUR :"
 
-#: pikaur/install_cli.py:69
+#: pikaur/install_cli.py:72
 msgid "Ignoring package {}"
 msgstr "Paquet {} ignoré"
 
-#: pikaur/build.py:261
+#: pikaur/build.py:277
 msgid "Installing already built dependencies for {}"
 msgstr "Installation des dépendances déjà construites pour {}"
 
-#: pikaur/build.py:409
+#: pikaur/build.py:418
 msgid "Installing repository dependencies for {}"
 msgstr "Installation des dépendances du dépôt pour {}"
 
-#: pikaur/pprint.py:223
+#: pikaur/pprint.py:252
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "La nouvelle dépendance sera installée depuis l'AUR :"
 msgstr[1] "Les nouvelles dépendances seront installées depuis l'AUR :"
 
-#: pikaur/install_cli.py:567
+#: pikaur/install_cli.py:605
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr ""
 "Le nouveau paquet '{new}' est en conflit avec le paquet installé "
 "'{installed}'."
 
-#: pikaur/install_cli.py:557
+#: pikaur/install_cli.py:622
+#, python-brace-format
+msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+msgstr ""
+"Le nouveau paquet '{new}' remplace le paquet installé '{installed}'. "
+"Continuer ?"
+
+#: pikaur/install_cli.py:593
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Les nouveaux paquets '{new}' et '{other}' sont en conflit."
 
-#: pikaur/install_cli.py:255
+#: pikaur/install_cli.py:283
 msgid "Nothing to do."
 msgstr "Rien à faire."
 
-#: pikaur/args.py:89
+#: pikaur/args.py:90
 msgid "Pikaur-specific options:"
 msgstr "Options spécifiques pikaur :"
 
-#: pikaur/install_cli.py:442
+#: pikaur/install_cli.py:472
 #, fuzzy
 msgid "Proceed with installation? [Y/n] "
 msgstr "Commencer l'installation ? [O/n]"
@@ -166,23 +173,23 @@ msgstr "Lecture de la base locale de paquets…"
 msgid "Reading repository package databases..."
 msgstr "Lecture des bases de données de paquets..."
 
-#: pikaur/build.py:451
+#: pikaur/build.py:452
 #, fuzzy
 msgid "Removing installed repository dependencies for {}"
 msgstr "Installation des dépendances du dépôt pour {}"
 
-#: pikaur/pprint.py:189
+#: pikaur/pprint.py:218
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "Le paquet du dépôt sera installé :"
 msgstr[1] "Les paquets du dépôt seront installés :"
 
-#: pikaur/install_cli.py:358
+#: pikaur/install_cli.py:388
 #, fuzzy
 msgid "Resolving AUR dependencies..."
 msgstr "résolution des dépendances…"
 
-#: pikaur/install_cli.py:777
+#: pikaur/install_cli.py:829
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Annulation de la transaction {target}…"
@@ -192,26 +199,26 @@ msgstr "Annulation de la transaction {target}…"
 msgid "Searching... [{bar}]"
 msgstr "Recherche… [{bar}]"
 
-#: pikaur/install_cli.py:582
+#: pikaur/install_cli.py:636
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Revue de {file} pour le paquet {name} ignorée ({flag})"
 
-#: pikaur/main.py:113
+#: pikaur/main.py:116
 msgid "Starting full AUR upgrade..."
 msgstr "Démarrage de la mise à jour complète AUR…"
 
-#: pikaur/pprint.py:201
+#: pikaur/pprint.py:230
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Le paquet de dépôt tiers sera installé :"
 msgstr[1] "Les paquets de dépôt tiers seront installés :"
 
-#: pikaur/install_cli.py:522
+#: pikaur/install_cli.py:558
 msgid "Try recovering?"
 msgstr "Essayer de récupérer ?"
 
-#: pikaur/install_cli.py:271
+#: pikaur/install_cli.py:299
 msgid "Version mismatch:"
 msgstr "Inadéquation des versions :"
 
@@ -224,11 +231,11 @@ msgstr "[O]ui (--noconfirm)"
 msgid "[Y]es (--noconfirm)"
 msgstr "[O]ui (--noconfirm)"
 
-#: pikaur/install_cli.py:527
+#: pikaur/install_cli.py:563
 msgid "[a] abort"
 msgstr "[a] annuler"
 
-#: pikaur/install_cli.py:523
+#: pikaur/install_cli.py:559
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
@@ -242,27 +249,27 @@ msgid "[installed]"
 msgstr "[installé]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:525
+#: pikaur/install_cli.py:561
 msgid "[r] remove dir and clone again"
 msgstr "[r] supprimer et cloner à nouveau"
 
-#: pikaur/install_cli.py:526
+#: pikaur/install_cli.py:562
 msgid "[s] skip this package"
 msgstr "[s] sauter ce paquet"
 
-#: pikaur/install_cli.py:444
+#: pikaur/install_cli.py:474
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[v]oir les détails du paquet   sélectionner [m]anuellement les paquets"
 
-#: pikaur/install_cli.py:518
+#: pikaur/install_cli.py:554 pikaur/install_cli.py:565
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:532
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:568
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:620
+#: pikaur/install_cli.py:688
 msgid "diff"
 msgstr "différences"
 
@@ -270,32 +277,42 @@ msgstr "différences"
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "ne pas demander de modifier les PKGBUILD et autres fichiers de build"
 
+#: pikaur/args.py:85
+#, fuzzy
+msgid "don't prompt to show the build files diff"
+msgstr "ne pas demander de modifier les PKGBUILD et autres fichiers de build"
+
 #: pikaur/args.py:84
 msgid "don't remove build dir after the build"
 msgstr ""
 
 # wrong case on purpose
-#: pikaur/install_cli.py:591
+#: pikaur/install_cli.py:645
 msgid "edit"
 msgstr "Modifier"
 
-#: pikaur/install_cli.py:699
+#: pikaur/main.py:266
+#, fuzzy
+msgid "error"
+msgstr "erreur :"
+
+#: pikaur/install_cli.py:753
 msgid "error:"
 msgstr "erreur :"
 
-#: pikaur/install_cli.py:546
+#: pikaur/install_cli.py:582
 msgid "looking for conflicting packages..."
 msgstr ""
 
-#: pikaur/install_cli.py:463
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:493
 msgid "m"
 msgstr "m"
 
-#: pikaur/prompt.py:15
+#: pikaur/prompt.py:15 pikaur/install_cli.py:476
 msgid "n"
 msgstr ""
 
-#: pikaur/install_cli.py:205
+#: pikaur/install_cli.py:230
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr "pas d'éditeur trouvé. Essayez de définir $VISUAL ou $EDITOR."
 
@@ -303,7 +320,7 @@ msgstr "pas d'éditeur trouvé. Essayez de définir $VISUAL ou $EDITOR."
 msgid "outofdate"
 msgstr ""
 
-#: pikaur/main.py:254
+#: pikaur/main.py:258
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr ""
 "pikaur nécessite systemd ≥ 235 (“dynamic users”) pour être lancé en root."
@@ -316,11 +333,11 @@ msgstr ""
 msgid "query packages from repository only"
 msgstr ""
 
-#: pikaur/install_cli.py:534
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:570
 msgid "r"
 msgstr "r"
 
-#: pikaur/install_cli.py:536
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:572
 msgid "s"
 msgstr "s"
 
@@ -332,19 +349,19 @@ msgstr "chercher uniquement dans les noms des paquets"
 msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr ""
 
-#: pikaur/install_cli.py:461
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:491
 msgid "v"
 msgstr "v"
 
-#: pikaur/install_cli.py:88 pikaur/install_cli.py:566 pikaur/pprint.py:87
+#: pikaur/install_cli.py:91 pikaur/install_cli.py:604 pikaur/pprint.py:106
 msgid "warning:"
 msgstr "attention :"
 
-#: pikaur/install_cli.py:459 pikaur/prompt.py:14
+#: pikaur/prompt.py:14 pikaur/install_cli.py:476 pikaur/install_cli.py:489
 msgid "y"
 msgstr "o"
 
-#: pikaur/install_cli.py:653
+#: pikaur/install_cli.py:114
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
@@ -352,12 +369,12 @@ msgstr ""
 "{name} ne peut pas être construit pour l'architecture actuelle ({arch}) mais "
 "uniquement {suparch}"
 
-#: pikaur/install_cli.py:89
+#: pikaur/install_cli.py:92
 #, fuzzy, python-brace-format
 msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr "{name} est à jour - ignoré"
 
-#: pikaur/install_cli.py:273
+#: pikaur/install_cli.py:301
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -370,7 +387,7 @@ msgstr ""
 msgid "{} does not exist on the filesystem."
 msgstr ""
 
-#: pikaur/main.py:167
+#: pikaur/main.py:171
 msgid "{}: {}"
 msgstr ""
 
@@ -382,11 +399,6 @@ msgstr ""
 
 #~ msgid "Getting ALL AUR info"
 #~ msgstr "Contenu de l'AUR"
-
-#~ msgid "New package '{new}' replaces installed '{installed}' Proceed?"
-#~ msgstr ""
-#~ "Le nouveau paquet '{new}' remplace le paquet installé '{installed}'. "
-#~ "Continuer ?"
 
 #~ msgid "Removing already installed dependencies for {}"
 #~ msgstr "Suppression des dépendances déjà installées pour {}"

--- a/locale/is.po
+++ b/locale/is.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-17 13:26+0000\n"
+"POT-Creation-Date: 2018-04-24 21:14+0200\n"
 "PO-Revision-Date: 2018-04-16 18:27+0000\n"
 "Last-Translator: Andri Viðar Tryggvason (andri@arivarton.com)\n"
 "Language-Team: none\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: pikaur/pprint.py:124
+#: pikaur/pprint.py:153
 msgid "({} days old)"
 msgstr "({} dagar gamall)"
 
-#: pikaur/pprint.py:212
+#: pikaur/pprint.py:241
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "AUR pakki verður sett upp:"
 msgstr[1] "AUR pakkar verða settir upp:"
 
-#: pikaur/install_cli.py:682
+#: pikaur/install_cli.py:736
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "Get ekki smíðað '{name}'."
 
-#: pikaur/install_cli.py:506
+#: pikaur/install_cli.py:542
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "Get ekki klónað '{name}' í '{path}' frá AUR:"
 
-#: pikaur/install_cli.py:508
+#: pikaur/install_cli.py:544
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "Get ekki togað '{name}' í '{path}' frá AUR:"
@@ -50,15 +50,15 @@ msgstr "Inning af skipun '{}' mistókst."
 msgid "Common pacman options:"
 msgstr "Algengir pacman valkostir:"
 
-#: pikaur/install_cli.py:266
+#: pikaur/install_cli.py:294
 msgid "Dependencies missing for {}"
 msgstr "Ákvæði vantar fyrir {}"
 
-#: pikaur/install_cli.py:700
+#: pikaur/install_cli.py:754
 msgid "Dependency cycle detected between {}"
 msgstr "Ákvæðis hringbraut uppgötvað á milli {}"
 
-#: pikaur/install_cli.py:208
+#: pikaur/install_cli.py:233
 msgid "Do you want to proceed without editing?"
 msgstr "Vilt þú halda áfram án þess að ritvinna?"
 
@@ -66,12 +66,12 @@ msgstr "Vilt þú halda áfram án þess að ritvinna?"
 msgid "Do you want to proceed?"
 msgstr "Vilt þú halda áfram?"
 
-#: pikaur/install_cli.py:572
+#: pikaur/install_cli.py:610
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Vilt þú fjarlægja '{installed}'?"
 
-#: pikaur/main.py:170
+#: pikaur/main.py:174
 msgid "Do you want to remove all files?"
 msgstr "Vilt þú fjarlægja allar skrár?"
 
@@ -79,71 +79,76 @@ msgstr "Vilt þú fjarlægja allar skrár?"
 msgid "Do you want to retry?"
 msgstr "Vilt þú reyna aftur?"
 
-#: pikaur/install_cli.py:619
+#: pikaur/install_cli.py:687
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Vilt þú sjá smíðaskrá {diff} fyrir {name} pakkan?"
 
-#: pikaur/install_cli.py:590
+#: pikaur/install_cli.py:644
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "Vilt þú {edit} {file} fyrir {name} pakkan?"
 
-#: pikaur/build.py:199
+#: pikaur/build.py:201
 msgid "Downloading the latest sources for a devel package {}"
 msgid_plural "Downloading the latest sources for devel packages {}"
 msgstr[0] "Niðurhleðsla af frumkóta í gángi fyrir devel pakkan {}"
 msgstr[1] "Niðurhleðsla af frumkóta í gángi fyrir devel pakka {}"
 
-#: pikaur/install_cli.py:174
+#: pikaur/install_cli.py:199
 msgid "Failed to build following packages:"
 msgstr "Mistókst að smíða eftirfarandi pakka:"
 
-#: pikaur/build.py:441
+#: pikaur/build.py:442
 msgid "Failed to remove installed dependencies, packages inconsistency: {}"
 msgstr "Mistókst að fjarlægja uppsett ákvæði, pakka ósamræmi: {}"
 
-#: pikaur/pprint.py:88
+#: pikaur/pprint.py:107
 msgid "Following packages cannot be found in AUR:"
 msgstr "Eftirfarandi pakkar finnast ekki í AUR:"
 
-#: pikaur/install_cli.py:69
+#: pikaur/install_cli.py:72
 msgid "Ignoring package {}"
 msgstr "Sé framhjá pakka {}"
 
-#: pikaur/build.py:261
+#: pikaur/build.py:277
 msgid "Installing already built dependencies for {}"
 msgstr "Set upp smíðuð ákvæði fyrir {}"
 
-#: pikaur/build.py:409
+#: pikaur/build.py:418
 msgid "Installing repository dependencies for {}"
 msgstr "Set upp gagnahírslu ákvæði fyrir {}"
 
-#: pikaur/pprint.py:223
+#: pikaur/pprint.py:252
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Nýtt ákvæði verður uppsett frá AUR:"
 msgstr[1] "Ný ákvæði verða uppsett frá AUR:"
 
-#: pikaur/install_cli.py:567
+#: pikaur/install_cli.py:605
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr "Nýr pakki '{new}' rekst á upsettan pakka '{installed}'."
 
-#: pikaur/install_cli.py:557
+#: pikaur/install_cli.py:622
+#, fuzzy, python-brace-format
+msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+msgstr "Nýr pakki '{new}' rekst á upsettan pakka '{installed}'."
+
+#: pikaur/install_cli.py:593
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Nýir pakkar '{new}' og '{other}' eru í árekstri."
 
-#: pikaur/install_cli.py:255
+#: pikaur/install_cli.py:283
 msgid "Nothing to do."
 msgstr "Ekkert að gera."
 
-#: pikaur/args.py:89
+#: pikaur/args.py:90
 msgid "Pikaur-specific options:"
 msgstr "Pikaur bundnir valkostir:"
 
-#: pikaur/install_cli.py:442
+#: pikaur/install_cli.py:472
 msgid "Proceed with installation? [Y/n] "
 msgstr "Halda áfram með upsettjíngu? [J/n] "
 
@@ -161,21 +166,21 @@ msgstr "Les staðvært pakkasafn..."
 msgid "Reading repository package databases..."
 msgstr "Les gagnahírt pakkasafn..."
 
-#: pikaur/build.py:451
+#: pikaur/build.py:452
 msgid "Removing installed repository dependencies for {}"
 msgstr "Fjarlægir uppsetta gagnahirslu ákvæði fyrir {}"
 
-#: pikaur/pprint.py:189
+#: pikaur/pprint.py:218
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "Gagnahirslu pakki verður uppsettur:"
 msgstr[1] "Gagnahirslu pakkar verða uppsettir:"
 
-#: pikaur/install_cli.py:358
+#: pikaur/install_cli.py:388
 msgid "Resolving AUR dependencies..."
 msgstr "Leysir AUR ákvæði..."
 
-#: pikaur/install_cli.py:777
+#: pikaur/install_cli.py:829
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Sný {target} hreyfingu..."
@@ -185,26 +190,26 @@ msgstr "Sný {target} hreyfingu..."
 msgid "Searching... [{bar}]"
 msgstr "Leitra... [{bar}]"
 
-#: pikaur/install_cli.py:582
+#: pikaur/install_cli.py:636
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Hleyp yfir könnun af {file} fyrir {name} pakka ({flag})"
 
-#: pikaur/main.py:113
+#: pikaur/main.py:116
 msgid "Starting full AUR upgrade..."
 msgstr "Byrja heila AUR uppfærslu..."
 
-#: pikaur/pprint.py:201
+#: pikaur/pprint.py:230
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Þriðja aðila gagnahírtur pakki verður uppsett:"
 msgstr[1] "Þriðja aðila gagnahírtir pakkar verða uppsettir:"
 
-#: pikaur/install_cli.py:522
+#: pikaur/install_cli.py:558
 msgid "Try recovering?"
 msgstr "Prufa að endurétta?"
 
-#: pikaur/install_cli.py:271
+#: pikaur/install_cli.py:299
 msgid "Version mismatch:"
 msgstr "Útgáfu misræmi:"
 
@@ -216,11 +221,11 @@ msgstr "[N]ei (--noconfirm)"
 msgid "[Y]es (--noconfirm)"
 msgstr "[J]á (--noconfirm)"
 
-#: pikaur/install_cli.py:527
+#: pikaur/install_cli.py:563
 msgid "[a] abort"
 msgstr "[s] slíta vinnslu"
 
-#: pikaur/install_cli.py:523
+#: pikaur/install_cli.py:559
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
@@ -234,27 +239,27 @@ msgid "[installed]"
 msgstr "[uppsett]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:525
+#: pikaur/install_cli.py:561
 msgid "[r] remove dir and clone again"
 msgstr "[f] fjarlægja efnisskrá og klóna aftur"
 
-#: pikaur/install_cli.py:526
+#: pikaur/install_cli.py:562
 msgid "[s] skip this package"
 msgstr "[h] hoppa yfir pakka"
 
-#: pikaur/install_cli.py:444
+#: pikaur/install_cli.py:474
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[s]oða pakka upplýsingar   [v]elja pakka handvirkt"
 
-#: pikaur/install_cli.py:518
+#: pikaur/install_cli.py:554 pikaur/install_cli.py:565
 msgid "a"
 msgstr "s"
 
-#: pikaur/install_cli.py:532
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:568
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:620
+#: pikaur/install_cli.py:688
 msgid "diff"
 msgstr "Breytingar"
 
@@ -262,31 +267,41 @@ msgstr "Breytingar"
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "ekki kveðja fyrir að ritvinna PKGBUILD og aðra smíðaskrár"
 
+#: pikaur/args.py:85
+#, fuzzy
+msgid "don't prompt to show the build files diff"
+msgstr "ekki kveðja fyrir að ritvinna PKGBUILD og aðra smíðaskrár"
+
 #: pikaur/args.py:84
 msgid "don't remove build dir after the build"
 msgstr "ekki fjarlægja smíðaskrá eftir smíði"
 
-#: pikaur/install_cli.py:591
+#: pikaur/install_cli.py:645
 msgid "edit"
 msgstr "Ritvinna"
 
-#: pikaur/install_cli.py:699
+#: pikaur/main.py:266
+#, fuzzy
+msgid "error"
+msgstr "Villa:"
+
+#: pikaur/install_cli.py:753
 msgid "error:"
 msgstr "Villa:"
 
-#: pikaur/install_cli.py:546
+#: pikaur/install_cli.py:582
 msgid "looking for conflicting packages..."
 msgstr "leita eftir pakka sem eru í árekstri..."
 
-#: pikaur/install_cli.py:463
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:493
 msgid "m"
 msgstr "v"
 
-#: pikaur/prompt.py:15
+#: pikaur/prompt.py:15 pikaur/install_cli.py:476
 msgid "n"
 msgstr "n"
 
-#: pikaur/install_cli.py:205
+#: pikaur/install_cli.py:230
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr "engin ritill fundinn. Prufaðu að skrá $VISUAL eða $EDITOR."
 
@@ -294,7 +309,7 @@ msgstr "engin ritill fundinn. Prufaðu að skrá $VISUAL eða $EDITOR."
 msgid "outofdate"
 msgstr "Úrelt"
 
-#: pikaur/main.py:254
+#: pikaur/main.py:258
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr ""
 "pikaur krefst þess að systemd >= 235 (dynamic users) verði innað sem root."
@@ -307,11 +322,11 @@ msgstr "bara fyrirspurja pakka frá AUR"
 msgid "query packages from repository only"
 msgstr "bara fyrirspurja pakka frá gagnahírslu"
 
-#: pikaur/install_cli.py:534
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:570
 msgid "r"
 msgstr "f"
 
-#: pikaur/install_cli.py:536
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:572
 msgid "s"
 msgstr "h"
 
@@ -323,31 +338,31 @@ msgstr "leita bara í pakka nöfnum"
 msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr "sysupgrade '-git' og aðrir dev pakkar eru eldri enn 1 dagur"
 
-#: pikaur/install_cli.py:461
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:491
 msgid "v"
 msgstr "s"
 
-#: pikaur/install_cli.py:88 pikaur/install_cli.py:566 pikaur/pprint.py:87
+#: pikaur/install_cli.py:91 pikaur/install_cli.py:604 pikaur/pprint.py:106
 msgid "warning:"
 msgstr "Viðvörun:"
 
-#: pikaur/install_cli.py:459 pikaur/prompt.py:14
+#: pikaur/prompt.py:14 pikaur/install_cli.py:476 pikaur/install_cli.py:489
 msgid "y"
 msgstr "j"
 
-#: pikaur/install_cli.py:653
+#: pikaur/install_cli.py:114
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
 msgstr ""
 "{name} getur ekki smíðast á þessari högund ({arch}). Annast í: {suparch}"
 
-#: pikaur/install_cli.py:89
+#: pikaur/install_cli.py:92
 #, python-brace-format
 msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr "{name} {version} {package_source} pakki er uppfærður - hoppa yfir"
 
-#: pikaur/install_cli.py:273
+#: pikaur/install_cli.py:301
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -360,6 +375,6 @@ msgstr ""
 msgid "{} does not exist on the filesystem."
 msgstr "{} er ekki til í skráakerfi."
 
-#: pikaur/main.py:167
+#: pikaur/main.py:171
 msgid "{}: {}"
 msgstr "{}: {}"

--- a/locale/pt.po
+++ b/locale/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pikaur\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-17 13:26+0000\n"
+"POT-Creation-Date: 2018-04-24 21:14+0200\n"
 "PO-Revision-Date: 2018-03-30 10:47-0300\n"
 "Last-Translator: Alexandre Lopes\n"
 "Language-Team: pt\n"
@@ -18,27 +18,27 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: pikaur/pprint.py:124
+#: pikaur/pprint.py:153
 msgid "({} days old)"
 msgstr "({} dias de idade)"
 
-#: pikaur/pprint.py:212
+#: pikaur/pprint.py:241
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "Pacote AUR será instalado:"
 msgstr[1] "Pacotes AUR serão instalados:"
 
-#: pikaur/install_cli.py:682
+#: pikaur/install_cli.py:736
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "Não é possível criar '{name}'."
 
-#: pikaur/install_cli.py:506
+#: pikaur/install_cli.py:542
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "Não é possível clonar '{name}' em '{path}' do AUR:"
 
-#: pikaur/install_cli.py:508
+#: pikaur/install_cli.py:544
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "Não é possível extrair '{name}' em '{path}' do AUR:"
@@ -51,15 +51,15 @@ msgstr "O comando '{}' falhou em executar."
 msgid "Common pacman options:"
 msgstr "Opções comuns do pacman:"
 
-#: pikaur/install_cli.py:266
+#: pikaur/install_cli.py:294
 msgid "Dependencies missing for {}"
 msgstr "Dependências ausentes para {}"
 
-#: pikaur/install_cli.py:700
+#: pikaur/install_cli.py:754
 msgid "Dependency cycle detected between {}"
 msgstr "Ciclo de dependência detectado entre {}"
 
-#: pikaur/install_cli.py:208
+#: pikaur/install_cli.py:233
 msgid "Do you want to proceed without editing?"
 msgstr "Você quer continuar sem editar?"
 
@@ -67,12 +67,12 @@ msgstr "Você quer continuar sem editar?"
 msgid "Do you want to proceed?"
 msgstr "Você quer prosseguir?"
 
-#: pikaur/install_cli.py:572
+#: pikaur/install_cli.py:610
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Você quer remover '{installed}'?"
 
-#: pikaur/main.py:170
+#: pikaur/main.py:174
 msgid "Do you want to remove all files?"
 msgstr "Você quer remover todos os arquivos?"
 
@@ -80,72 +80,77 @@ msgstr "Você quer remover todos os arquivos?"
 msgid "Do you want to retry?"
 msgstr "Você quer tentar de novo?"
 
-#: pikaur/install_cli.py:619
+#: pikaur/install_cli.py:687
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Deseja ver os arquivos de compilação {diff} para o pacote {name}?"
 
-#: pikaur/install_cli.py:590
+#: pikaur/install_cli.py:644
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "Deseja {edit} {file} para o pacote {name}?"
 
-#: pikaur/build.py:199
+#: pikaur/build.py:201
 msgid "Downloading the latest sources for a devel package {}"
 msgid_plural "Downloading the latest sources for devel packages {}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pikaur/install_cli.py:174
+#: pikaur/install_cli.py:199
 msgid "Failed to build following packages:"
 msgstr "Falha ao criar os seguintes pacotes:"
 
-#: pikaur/build.py:441
+#: pikaur/build.py:442
 msgid "Failed to remove installed dependencies, packages inconsistency: {}"
 msgstr ""
 
-#: pikaur/pprint.py:88
+#: pikaur/pprint.py:107
 msgid "Following packages cannot be found in AUR:"
 msgstr "Os seguintes pacotes não podem ser encontrados no AUR:"
 
-#: pikaur/install_cli.py:69
+#: pikaur/install_cli.py:72
 msgid "Ignoring package {}"
 msgstr "Ignorando o pacote {}"
 
-#: pikaur/build.py:261
+#: pikaur/build.py:277
 msgid "Installing already built dependencies for {}"
 msgstr "Instalando dependências já construídas para {}"
 
-#: pikaur/build.py:409
+#: pikaur/build.py:418
 #, fuzzy
 msgid "Installing repository dependencies for {}"
 msgstr "Instalando dependências já construídas para {}"
 
-#: pikaur/pprint.py:223
+#: pikaur/pprint.py:252
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Nova dependência será instalada a partir do AUR:"
 msgstr[1] "Novas dependências serão instaladas a partir do AUR:"
 
-#: pikaur/install_cli.py:567
+#: pikaur/install_cli.py:605
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr "O novo pacote '{new}' está em conflito com o '{installed}' instalado."
 
-#: pikaur/install_cli.py:557
+#: pikaur/install_cli.py:622
+#, fuzzy, python-brace-format
+msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+msgstr "O novo pacote '{new}' está em conflito com o '{installed}' instalado."
+
+#: pikaur/install_cli.py:593
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Novos pacotes '{new}' e '{other}' estão em conflito."
 
-#: pikaur/install_cli.py:255
+#: pikaur/install_cli.py:283
 msgid "Nothing to do."
 msgstr "Nada para fazer."
 
-#: pikaur/args.py:89
+#: pikaur/args.py:90
 msgid "Pikaur-specific options:"
 msgstr "Opções específicas do Pikaur:"
 
-#: pikaur/install_cli.py:442
+#: pikaur/install_cli.py:472
 msgid "Proceed with installation? [Y/n] "
 msgstr "Continuar com a instalação? [Y/n] "
 
@@ -163,22 +168,22 @@ msgstr "Lendo o banco de dados de pacotes local..."
 msgid "Reading repository package databases..."
 msgstr "Lendo bancos de dados de pacotes do repositório..."
 
-#: pikaur/build.py:451
+#: pikaur/build.py:452
 #, fuzzy
 msgid "Removing installed repository dependencies for {}"
 msgstr "Instalando dependências já construídas para {}"
 
-#: pikaur/pprint.py:189
+#: pikaur/pprint.py:218
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "O pacote do repositório será instalado:"
 msgstr[1] "Pacotes de repositório serão instalados:"
 
-#: pikaur/install_cli.py:358
+#: pikaur/install_cli.py:388
 msgid "Resolving AUR dependencies..."
 msgstr "Resolvendo dependências do AUR..."
 
-#: pikaur/install_cli.py:777
+#: pikaur/install_cli.py:829
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Revertendo a transação {target}..."
@@ -188,26 +193,26 @@ msgstr "Revertendo a transação {target}..."
 msgid "Searching... [{bar}]"
 msgstr "Procurando... [{bar}]"
 
-#: pikaur/install_cli.py:582
+#: pikaur/install_cli.py:636
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Ignorando a revisão de {file} para o pacote {name} ({flag})"
 
-#: pikaur/main.py:113
+#: pikaur/main.py:116
 msgid "Starting full AUR upgrade..."
 msgstr "Iniciando a atualização completa do AUR..."
 
-#: pikaur/pprint.py:201
+#: pikaur/pprint.py:230
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "O pacote de repositórios de terceiros será instalado:"
 msgstr[1] "Pacotes de repositórios de terceiros serão instalados:"
 
-#: pikaur/install_cli.py:522
+#: pikaur/install_cli.py:558
 msgid "Try recovering?"
 msgstr "Tente recuperar?"
 
-#: pikaur/install_cli.py:271
+#: pikaur/install_cli.py:299
 msgid "Version mismatch:"
 msgstr "Incompatibilidade de versão:"
 
@@ -220,11 +225,11 @@ msgstr "[Y]es (--noconfirm)"
 msgid "[Y]es (--noconfirm)"
 msgstr "[Y]es (--noconfirm)"
 
-#: pikaur/install_cli.py:527
+#: pikaur/install_cli.py:563
 msgid "[a] abort"
 msgstr "[a] abortar"
 
-#: pikaur/install_cli.py:523
+#: pikaur/install_cli.py:559
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout --'*'"
 
@@ -238,27 +243,27 @@ msgid "[installed]"
 msgstr "[instalado]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:525
+#: pikaur/install_cli.py:561
 msgid "[r] remove dir and clone again"
 msgstr "[r] remova o dir e clone novamente"
 
-#: pikaur/install_cli.py:526
+#: pikaur/install_cli.py:562
 msgid "[s] skip this package"
 msgstr "[s] pule este pacote"
 
-#: pikaur/install_cli.py:444
+#: pikaur/install_cli.py:474
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[v]er detalhe do pacote   selecionar pacotes [m]anualmente"
 
-#: pikaur/install_cli.py:518
+#: pikaur/install_cli.py:554 pikaur/install_cli.py:565
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:532
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:568
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:620
+#: pikaur/install_cli.py:688
 msgid "diff"
 msgstr "diff"
 
@@ -266,31 +271,41 @@ msgstr "diff"
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "não solicite a edição de PKGBUILDs e outros arquivos de compilação"
 
+#: pikaur/args.py:85
+#, fuzzy
+msgid "don't prompt to show the build files diff"
+msgstr "não solicite a edição de PKGBUILDs e outros arquivos de compilação"
+
 #: pikaur/args.py:84
 msgid "don't remove build dir after the build"
 msgstr ""
 
-#: pikaur/install_cli.py:591
+#: pikaur/install_cli.py:645
 msgid "edit"
 msgstr "editar"
 
-#: pikaur/install_cli.py:699
+#: pikaur/main.py:266
+#, fuzzy
+msgid "error"
+msgstr "erro:"
+
+#: pikaur/install_cli.py:753
 msgid "error:"
 msgstr "erro:"
 
-#: pikaur/install_cli.py:546
+#: pikaur/install_cli.py:582
 msgid "looking for conflicting packages..."
 msgstr "procurando pacotes conflitantes..."
 
-#: pikaur/install_cli.py:463
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:493
 msgid "m"
 msgstr "m"
 
-#: pikaur/prompt.py:15
+#: pikaur/prompt.py:15 pikaur/install_cli.py:476
 msgid "n"
 msgstr ""
 
-#: pikaur/install_cli.py:205
+#: pikaur/install_cli.py:230
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr "nenhum editor encontrado. Tente definir $VISUAL ou $EDITOR."
 
@@ -298,7 +313,7 @@ msgstr "nenhum editor encontrado. Tente definir $VISUAL ou $EDITOR."
 msgid "outofdate"
 msgstr ""
 
-#: pikaur/main.py:254
+#: pikaur/main.py:258
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr ""
 "pikaur requer systemd >= 235 (usuários dinâmicos) para ser executado como "
@@ -312,11 +327,11 @@ msgstr "pacotes de consulta apenas do AUR"
 msgid "query packages from repository only"
 msgstr "pacotes de consulta apenas do repositório"
 
-#: pikaur/install_cli.py:534
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:570
 msgid "r"
 msgstr "r"
 
-#: pikaur/install_cli.py:536
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:572
 msgid "s"
 msgstr "s"
 
@@ -329,31 +344,31 @@ msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr ""
 "sysupgrade '-git' e outros pacotes de desenvolvimento com mais de 1 dia"
 
-#: pikaur/install_cli.py:461
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:491
 msgid "v"
 msgstr "v"
 
-#: pikaur/install_cli.py:88 pikaur/install_cli.py:566 pikaur/pprint.py:87
+#: pikaur/install_cli.py:91 pikaur/install_cli.py:604 pikaur/pprint.py:106
 msgid "warning:"
 msgstr "atenção:"
 
-#: pikaur/install_cli.py:459 pikaur/prompt.py:14
+#: pikaur/prompt.py:14 pikaur/install_cli.py:476 pikaur/install_cli.py:489
 msgid "y"
 msgstr "y"
 
-#: pikaur/install_cli.py:653
+#: pikaur/install_cli.py:114
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
 msgstr ""
 "{name} não pode ser criado no arco atual ({arch}). Suportado: {suparch}"
 
-#: pikaur/install_cli.py:89
+#: pikaur/install_cli.py:92
 #, fuzzy, python-brace-format
 msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr "{name} O repositório AUR está atualizado - ignorando"
 
-#: pikaur/install_cli.py:273
+#: pikaur/install_cli.py:301
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -366,7 +381,7 @@ msgstr ""
 msgid "{} does not exist on the filesystem."
 msgstr "{} não existe no sistema de arquivos."
 
-#: pikaur/main.py:167
+#: pikaur/main.py:171
 msgid "{}: {}"
 msgstr ""
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-17 13:26+0000\n"
+"POT-Creation-Date: 2018-04-24 21:14+0200\n"
 "PO-Revision-Date: 2018-03-09 20:31+0300\n"
 "Last-Translator: Mauladen <twertrue@yandex.ru>\n"
 "Language-Team: none\n"
@@ -18,27 +18,27 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: pikaur/pprint.py:124
+#: pikaur/pprint.py:153
 msgid "({} days old)"
 msgstr ""
 
-#: pikaur/pprint.py:212
+#: pikaur/pprint.py:241
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "Будет установлен пакет из AUR:"
 msgstr[1] "Будут установлены пакеты из AUR:"
 
-#: pikaur/install_cli.py:682
+#: pikaur/install_cli.py:736
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "Невозможно собрать '{name}'."
 
-#: pikaur/install_cli.py:506
+#: pikaur/install_cli.py:542
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "Невозможно клонировать пакет '{name}' из AUR по пути '{path}':"
 
-#: pikaur/install_cli.py:508
+#: pikaur/install_cli.py:544
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "Невозможно обновить пакет '{name}' из AUR по пути '{path}':"
@@ -51,15 +51,15 @@ msgstr "Не удалось выполнить команду '{}'."
 msgid "Common pacman options:"
 msgstr "Стандартные параметры pacman:"
 
-#: pikaur/install_cli.py:266
+#: pikaur/install_cli.py:294
 msgid "Dependencies missing for {}"
 msgstr "Отсутствуют зависимости для {}"
 
-#: pikaur/install_cli.py:700
+#: pikaur/install_cli.py:754
 msgid "Dependency cycle detected between {}"
 msgstr "Обнаружена циклическая зависимость между {}"
 
-#: pikaur/install_cli.py:208
+#: pikaur/install_cli.py:233
 msgid "Do you want to proceed without editing?"
 msgstr "Хотите ли вы продолжить без редактирования?"
 
@@ -67,12 +67,12 @@ msgstr "Хотите ли вы продолжить без редактиров�
 msgid "Do you want to proceed?"
 msgstr "Хотите ли вы продолжить?"
 
-#: pikaur/install_cli.py:572
+#: pikaur/install_cli.py:610
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "Вы действительно хотите удалить '{installed}'?"
 
-#: pikaur/main.py:170
+#: pikaur/main.py:174
 msgid "Do you want to remove all files?"
 msgstr "Вы действительно хотите удалить все файлы?"
 
@@ -80,71 +80,76 @@ msgstr "Вы действительно хотите удалить все фа�
 msgid "Do you want to retry?"
 msgstr "Хотите ли вы попробовать снова?"
 
-#: pikaur/install_cli.py:619
+#: pikaur/install_cli.py:687
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "Хотите ли вы просмотреть {diff} файлов сборки для пакета {name}?"
 
-#: pikaur/install_cli.py:590
+#: pikaur/install_cli.py:644
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "Хотите ли вы {edit} {file} из пакета {name}?"
 
-#: pikaur/build.py:199
+#: pikaur/build.py:201
 msgid "Downloading the latest sources for a devel package {}"
 msgid_plural "Downloading the latest sources for devel packages {}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pikaur/install_cli.py:174
+#: pikaur/install_cli.py:199
 msgid "Failed to build following packages:"
 msgstr "Не удалось собрать данные пакеты:"
 
-#: pikaur/build.py:441
+#: pikaur/build.py:442
 msgid "Failed to remove installed dependencies, packages inconsistency: {}"
 msgstr ""
 
-#: pikaur/pprint.py:88
+#: pikaur/pprint.py:107
 msgid "Following packages cannot be found in AUR:"
 msgstr "Данные пакеты не могут быть найдены в AUR:"
 
-#: pikaur/install_cli.py:69
+#: pikaur/install_cli.py:72
 msgid "Ignoring package {}"
 msgstr "Пакет {} был проигнорирован"
 
-#: pikaur/build.py:261
+#: pikaur/build.py:277
 msgid "Installing already built dependencies for {}"
 msgstr "Установка уже собранных зависимостей для {}"
 
-#: pikaur/build.py:409
+#: pikaur/build.py:418
 msgid "Installing repository dependencies for {}"
 msgstr "Установка зависимостей из репозиториев для {}"
 
-#: pikaur/pprint.py:223
+#: pikaur/pprint.py:252
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Будет установлена новая зависимость из AUR:"
 msgstr[1] "Будут установлены новые зависимости из AUR:"
 
-#: pikaur/install_cli.py:567
+#: pikaur/install_cli.py:605
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr "Новый пакет '{new}' конфликтует с установленным '{installed}'."
 
-#: pikaur/install_cli.py:557
+#: pikaur/install_cli.py:622
+#, python-brace-format
+msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+msgstr "Новый пакет '{new}' заменяет установленный '{installed}' Продолжить?"
+
+#: pikaur/install_cli.py:593
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Новые пакеты '{new}' и '{other}' конфликтуют."
 
-#: pikaur/install_cli.py:255
+#: pikaur/install_cli.py:283
 msgid "Nothing to do."
 msgstr "Нечего делать."
 
-#: pikaur/args.py:89
+#: pikaur/args.py:90
 msgid "Pikaur-specific options:"
 msgstr "Опции pikaur:"
 
-#: pikaur/install_cli.py:442
+#: pikaur/install_cli.py:472
 #, fuzzy
 msgid "Proceed with installation? [Y/n] "
 msgstr "Продолжить установку? [Y/n]"
@@ -163,23 +168,23 @@ msgstr "Чтение локальной базы данных пакетов..."
 msgid "Reading repository package databases..."
 msgstr "Чтение баз данных пакетов из репозиториев..."
 
-#: pikaur/build.py:451
+#: pikaur/build.py:452
 #, fuzzy
 msgid "Removing installed repository dependencies for {}"
 msgstr "Установка зависимостей из репозиториев для {}"
 
-#: pikaur/pprint.py:189
+#: pikaur/pprint.py:218
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "Будет установлен следующий пакет из репозиториев:"
 msgstr[1] "Будут установлены следующие пакеты из репозиториев:"
 
-#: pikaur/install_cli.py:358
+#: pikaur/install_cli.py:388
 #, fuzzy
 msgid "Resolving AUR dependencies..."
 msgstr "разрешение зависимостей..."
 
-#: pikaur/install_cli.py:777
+#: pikaur/install_cli.py:829
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "Откат транзакции {target}..."
@@ -189,27 +194,27 @@ msgstr "Откат транзакции {target}..."
 msgid "Searching... [{bar}]"
 msgstr "Поиск... [{bar}]"
 
-#: pikaur/install_cli.py:582
+#: pikaur/install_cli.py:636
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
 msgstr "Пропуск проверки файла {file} для пакета {name} ({flag})"
 
-#: pikaur/main.py:113
+#: pikaur/main.py:116
 msgid "Starting full AUR upgrade..."
 msgstr "Запуск полного обновления пакетов из AUR..."
 
-#: pikaur/pprint.py:201
+#: pikaur/pprint.py:230
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Будет установлен следующий пакет из неофициальных репозиториев:"
 msgstr[1] "Будут установлены следующие пакеты из неофициальных репозиториев:"
 
 # This can probably have better translation, but I didn't find any
-#: pikaur/install_cli.py:522
+#: pikaur/install_cli.py:558
 msgid "Try recovering?"
 msgstr "Попробовать восстановить?"
 
-#: pikaur/install_cli.py:271
+#: pikaur/install_cli.py:299
 msgid "Version mismatch:"
 msgstr "Несовпадение версии:"
 
@@ -222,11 +227,11 @@ msgstr "[Y]es (--noconfirm)"
 msgid "[Y]es (--noconfirm)"
 msgstr "[Y]es (--noconfirm)"
 
-#: pikaur/install_cli.py:527
+#: pikaur/install_cli.py:563
 msgid "[a] abort"
 msgstr "[a] отмена"
 
-#: pikaur/install_cli.py:523
+#: pikaur/install_cli.py:559
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
@@ -240,27 +245,27 @@ msgid "[installed]"
 msgstr "[установлен]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:525
+#: pikaur/install_cli.py:561
 msgid "[r] remove dir and clone again"
 msgstr "[r] удалить директорию и клонировать заново"
 
-#: pikaur/install_cli.py:526
+#: pikaur/install_cli.py:562
 msgid "[s] skip this package"
 msgstr "[s] пропустить этот пакет"
 
-#: pikaur/install_cli.py:444
+#: pikaur/install_cli.py:474
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "[v] просмотреть описания пакетов   [m] вручную выбрать пакеты"
 
-#: pikaur/install_cli.py:518
+#: pikaur/install_cli.py:554 pikaur/install_cli.py:565
 msgid "a"
 msgstr "a"
 
-#: pikaur/install_cli.py:532
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:568
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:620
+#: pikaur/install_cli.py:688
 msgid "diff"
 msgstr "различия"
 
@@ -268,31 +273,41 @@ msgstr "различия"
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "не запрашивать редактирование файлов PKGBUILD и других файлов сборки"
 
+#: pikaur/args.py:85
+#, fuzzy
+msgid "don't prompt to show the build files diff"
+msgstr "не запрашивать редактирование файлов PKGBUILD и других файлов сборки"
+
 #: pikaur/args.py:84
 msgid "don't remove build dir after the build"
 msgstr ""
 
-#: pikaur/install_cli.py:591
+#: pikaur/install_cli.py:645
 msgid "edit"
 msgstr "отредактировать"
 
-#: pikaur/install_cli.py:699
+#: pikaur/main.py:266
+#, fuzzy
+msgid "error"
+msgstr "ошибка:"
+
+#: pikaur/install_cli.py:753
 msgid "error:"
 msgstr "ошибка:"
 
-#: pikaur/install_cli.py:546
+#: pikaur/install_cli.py:582
 msgid "looking for conflicting packages..."
 msgstr "поиск конфликтующих пакетов..."
 
-#: pikaur/install_cli.py:463
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:493
 msgid "m"
 msgstr "m"
 
-#: pikaur/prompt.py:15
+#: pikaur/prompt.py:15 pikaur/install_cli.py:476
 msgid "n"
 msgstr ""
 
-#: pikaur/install_cli.py:205
+#: pikaur/install_cli.py:230
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr ""
 "редактор не найден. Попробуйте установить переменную окружения $VISUAL или "
@@ -302,7 +317,7 @@ msgstr ""
 msgid "outofdate"
 msgstr ""
 
-#: pikaur/main.py:254
+#: pikaur/main.py:258
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
 msgstr ""
 "pikaur требует systemd >= 235 (поддержка динамических пользователей) для "
@@ -316,11 +331,11 @@ msgstr ""
 msgid "query packages from repository only"
 msgstr ""
 
-#: pikaur/install_cli.py:534
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:570
 msgid "r"
 msgstr "r"
 
-#: pikaur/install_cli.py:536
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:572
 msgid "s"
 msgstr "s"
 
@@ -332,19 +347,19 @@ msgstr "искать только в именах пакетов"
 msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr ""
 
-#: pikaur/install_cli.py:461
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:491
 msgid "v"
 msgstr "v"
 
-#: pikaur/install_cli.py:88 pikaur/install_cli.py:566 pikaur/pprint.py:87
+#: pikaur/install_cli.py:91 pikaur/install_cli.py:604 pikaur/pprint.py:106
 msgid "warning:"
 msgstr "внимание:"
 
-#: pikaur/install_cli.py:459 pikaur/prompt.py:14
+#: pikaur/prompt.py:14 pikaur/install_cli.py:476 pikaur/install_cli.py:489
 msgid "y"
 msgstr "y"
 
-#: pikaur/install_cli.py:653
+#: pikaur/install_cli.py:114
 #, python-brace-format
 msgid ""
 "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
@@ -352,12 +367,12 @@ msgstr ""
 "{name} не может быть собран на текущей архитектуре ({arch}). Поддерживаемые "
 "архитектуры: {suparch}"
 
-#: pikaur/install_cli.py:89
+#: pikaur/install_cli.py:92
 #, fuzzy, python-brace-format
 msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr "{name} уже обновлён - пропуск"
 
-#: pikaur/install_cli.py:273
+#: pikaur/install_cli.py:301
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -370,7 +385,7 @@ msgstr ""
 msgid "{} does not exist on the filesystem."
 msgstr ""
 
-#: pikaur/main.py:167
+#: pikaur/main.py:171
 msgid "{}: {}"
 msgstr ""
 
@@ -382,10 +397,6 @@ msgstr ""
 
 #~ msgid "Getting ALL AUR info"
 #~ msgstr "Получение всех данных из AUR"
-
-#~ msgid "New package '{new}' replaces installed '{installed}' Proceed?"
-#~ msgstr ""
-#~ "Новый пакет '{new}' заменяет установленный '{installed}' Продолжить?"
 
 #~ msgid "Removing already installed dependencies for {}"
 #~ msgstr "Удаление уже установленных зависимостей {}"

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-19 22:56+0300\n"
+"POT-Creation-Date: 2018-04-24 21:14+0200\n"
 "PO-Revision-Date: 2018-04-19 23:46+0300\n"
 "Last-Translator: Osman Karagöz <osmank3@gmail.com>\n"
 "Language-Team: none\n"
@@ -19,27 +19,27 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: pikaur/pprint.py:124
+#: pikaur/pprint.py:153
 msgid "({} days old)"
 msgstr "({} gün eski)"
 
-#: pikaur/pprint.py:212
+#: pikaur/pprint.py:241
 msgid "AUR package will be installed:"
 msgid_plural "AUR packages will be installed:"
 msgstr[0] "AUR paketi kurulacak:"
 msgstr[1] "AUR paketleri kurulacak:"
 
-#: pikaur/install_cli.py:694
+#: pikaur/install_cli.py:736
 #, python-brace-format
 msgid "Can't build '{name}'."
 msgstr "'{name}' inşa edilemedi."
 
-#: pikaur/install_cli.py:514
+#: pikaur/install_cli.py:542
 #, python-brace-format
 msgid "Can't clone '{name}' in '{path}' from AUR:"
 msgstr "AUR'dan '{path}' içindeki '{name}' klonlanamadı:"
 
-#: pikaur/install_cli.py:516
+#: pikaur/install_cli.py:544
 #, python-brace-format
 msgid "Can't pull '{name}' in '{path}' from AUR:"
 msgstr "AUR'dan '{path}' içindeki '{name}' çekilemedi:"
@@ -52,15 +52,15 @@ msgstr "'{}' komutu çalıştırılamadı."
 msgid "Common pacman options:"
 msgstr "Ortak pacman seçenekleri:"
 
-#: pikaur/install_cli.py:269
+#: pikaur/install_cli.py:294
 msgid "Dependencies missing for {}"
 msgstr "{} için bağımlılıklar eksik"
 
-#: pikaur/install_cli.py:712
+#: pikaur/install_cli.py:754
 msgid "Dependency cycle detected between {}"
 msgstr "{} ile bağımlılık döngüsü tespit edildi"
 
-#: pikaur/install_cli.py:208
+#: pikaur/install_cli.py:233
 msgid "Do you want to proceed without editing?"
 msgstr "Düzenlemeden devam etmek ister misiniz?"
 
@@ -68,12 +68,12 @@ msgstr "Düzenlemeden devam etmek ister misiniz?"
 msgid "Do you want to proceed?"
 msgstr "Devam etmek ister misiniz?"
 
-#: pikaur/install_cli.py:582
+#: pikaur/install_cli.py:610
 #, python-brace-format
 msgid "Do you want to remove '{installed}'?"
 msgstr "'{installed}' kaldırmak ister misiniz?"
 
-#: pikaur/main.py:170
+#: pikaur/main.py:174
 msgid "Do you want to remove all files?"
 msgstr "Tüm dosyaları silmek ister misiniz?"
 
@@ -81,71 +81,76 @@ msgstr "Tüm dosyaları silmek ister misiniz?"
 msgid "Do you want to retry?"
 msgstr "Tekrar denemek ister misiniz?"
 
-#: pikaur/install_cli.py:629
+#: pikaur/install_cli.py:687
 #, python-brace-format
 msgid "Do you want to see build files {diff} for {name} package?"
 msgstr "{name} paketi için inşa dosyaları {diff} görmek ister misiniz?"
 
-#: pikaur/install_cli.py:600
+#: pikaur/install_cli.py:644
 #, python-brace-format
 msgid "Do you want to {edit} {file} for {name} package?"
 msgstr "{name} paketi için {file} {edit} ister misiniz?"
 
-#: pikaur/build.py:200
+#: pikaur/build.py:201
 msgid "Downloading the latest sources for a devel package {}"
 msgid_plural "Downloading the latest sources for devel packages {}"
 msgstr[0] "Geliştirici paketi için güncel kaynaklar indiriliyor {}"
 msgstr[1] "Geliştirici paketleri için güncel kaynaklar indiriliyor {}"
 
-#: pikaur/install_cli.py:174
+#: pikaur/install_cli.py:199
 msgid "Failed to build following packages:"
 msgstr "Paketler inşa edilemedi:"
 
-#: pikaur/build.py:437
+#: pikaur/build.py:442
 msgid "Failed to remove installed dependencies, packages inconsistency: {}"
 msgstr "Kurulan bağımlılıklar silinemedi, paketler tutarsız: {}"
 
-#: pikaur/pprint.py:88
+#: pikaur/pprint.py:107
 msgid "Following packages cannot be found in AUR:"
 msgstr "Paketler AUR'da bulunamadı:"
 
-#: pikaur/install_cli.py:69
+#: pikaur/install_cli.py:72
 msgid "Ignoring package {}"
 msgstr "Paket gözardı ediliyor {}"
 
-#: pikaur/build.py:269
+#: pikaur/build.py:277
 msgid "Installing already built dependencies for {}"
 msgstr "{} için inşa edilmiş paketler kuruluyor"
 
-#: pikaur/build.py:412
+#: pikaur/build.py:418
 msgid "Installing repository dependencies for {}"
 msgstr "{} için depo bağımlılıkları kuruluyor"
 
-#: pikaur/pprint.py:223
+#: pikaur/pprint.py:252
 msgid "New dependency will be installed from AUR:"
 msgid_plural "New dependencies will be installed from AUR:"
 msgstr[0] "Yeni bağlılık AUR'dan kurulacak:"
 msgstr[1] "Yeni bağlılıklar AUR'dan kurulacak:"
 
-#: pikaur/install_cli.py:577
+#: pikaur/install_cli.py:605
 #, python-brace-format
 msgid "New package '{new}' conflicts with installed '{installed}'."
 msgstr "Yeni '{new}' paketi ile kurulu '{installed}' çakışıyor."
 
-#: pikaur/install_cli.py:565
+#: pikaur/install_cli.py:622
+#, fuzzy, python-brace-format
+msgid "New package '{new}' replaces installed '{installed}' Proceed?"
+msgstr "Yeni '{new}' paketi ile kurulu '{installed}' çakışıyor."
+
+#: pikaur/install_cli.py:593
 #, python-brace-format
 msgid "New packages '{new}' and '{other}' are in conflict."
 msgstr "Yeni '{new}' paketleri ile '{other}' çakışıyor."
 
-#: pikaur/install_cli.py:258
+#: pikaur/install_cli.py:283
 msgid "Nothing to do."
 msgstr "Yapacak bişey yok."
 
-#: pikaur/args.py:89
+#: pikaur/args.py:90
 msgid "Pikaur-specific options:"
 msgstr "Pikaur-özel seçenekler:"
 
-#: pikaur/install_cli.py:447
+#: pikaur/install_cli.py:472
 msgid "Proceed with installation? [Y/n] "
 msgstr "Kuruluma devam edilsin mi? [E/h] "
 
@@ -163,21 +168,21 @@ msgstr "Yerel paket veritabanı okunuyor..."
 msgid "Reading repository package databases..."
 msgstr "Depo paket veritabanı okunuyor..."
 
-#: pikaur/build.py:447
+#: pikaur/build.py:452
 msgid "Removing installed repository dependencies for {}"
 msgstr "{} için kurulan depo bağımlılıkları siliniyor"
 
-#: pikaur/pprint.py:189
+#: pikaur/pprint.py:218
 msgid "Repository package will be installed:"
 msgid_plural "Repository packages will be installed:"
 msgstr[0] "Depo paketi kurulacak:"
 msgstr[1] "Depo paketleri kurulacak:"
 
-#: pikaur/install_cli.py:363
+#: pikaur/install_cli.py:388
 msgid "Resolving AUR dependencies..."
 msgstr "AUR bağımlılıkları çözülüyor..."
 
-#: pikaur/install_cli.py:789
+#: pikaur/install_cli.py:829
 #, python-brace-format
 msgid "Reverting {target} transaction..."
 msgstr "{target} işlem geri alınıyor..."
@@ -187,26 +192,27 @@ msgstr "{target} işlem geri alınıyor..."
 msgid "Searching... [{bar}]"
 msgstr "Aranıyor... [{bar}]"
 
-#: pikaur/install_cli.py:592
+#: pikaur/install_cli.py:636
 #, python-brace-format
 msgid "Skipping review of {file} for {name} package ({flag})"
-msgstr "{name} paketindeki {file} dosyanın gösden geçirilmesi atlanıyor ({flag})"
+msgstr ""
+"{name} paketindeki {file} dosyanın gösden geçirilmesi atlanıyor ({flag})"
 
-#: pikaur/main.py:113
+#: pikaur/main.py:116
 msgid "Starting full AUR upgrade..."
 msgstr "Tam AUR güncellemesi başlatılıyor..."
 
-#: pikaur/pprint.py:201
+#: pikaur/pprint.py:230
 msgid "Third-party repository package will be installed:"
 msgid_plural "Third-party repository packages will be installed:"
 msgstr[0] "Üçüncü-parti depo paketi kurulacak:"
 msgstr[1] "Üçüncü-parti depo paketleri kurulacak:"
 
-#: pikaur/install_cli.py:530
+#: pikaur/install_cli.py:558
 msgid "Try recovering?"
 msgstr "Kurtarmayı dene?"
 
-#: pikaur/install_cli.py:274
+#: pikaur/install_cli.py:299
 msgid "Version mismatch:"
 msgstr "Sürüm uyumsuzluğu:"
 
@@ -218,11 +224,11 @@ msgstr "[H]ayır (--noconfirm)"
 msgid "[Y]es (--noconfirm)"
 msgstr "[E]vet (--noconfirm)"
 
-#: pikaur/install_cli.py:535
+#: pikaur/install_cli.py:563
 msgid "[a] abort"
 msgstr "[v] vazgeç"
 
-#: pikaur/install_cli.py:531
+#: pikaur/install_cli.py:559
 msgid "[c] git checkout -- '*'"
 msgstr "[c] git checkout -- '*'"
 
@@ -236,27 +242,27 @@ msgid "[installed]"
 msgstr "[kurulu]"
 
 #. _("[c] git checkout -- '*' ; git clean -f -d -x"),
-#: pikaur/install_cli.py:533
+#: pikaur/install_cli.py:561
 msgid "[r] remove dir and clone again"
 msgstr "[s] dizini sil ve tekrar klonla"
 
-#: pikaur/install_cli.py:534
+#: pikaur/install_cli.py:562
 msgid "[s] skip this package"
 msgstr "[a] bu paketi atla"
 
-#: pikaur/install_cli.py:449
+#: pikaur/install_cli.py:474
 msgid "[v]iew package detail   [m]anually select packages"
 msgstr "paket detaylarını [g]öster   paketleri elle se[ç]"
 
-#: pikaur/install_cli.py:526
+#: pikaur/install_cli.py:554 pikaur/install_cli.py:565
 msgid "a"
 msgstr "v"
 
-#: pikaur/install_cli.py:540
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:568
 msgid "c"
 msgstr "c"
 
-#: pikaur/install_cli.py:630
+#: pikaur/install_cli.py:688
 msgid "diff"
 msgstr "fark"
 
@@ -264,31 +270,41 @@ msgstr "fark"
 msgid "don't prompt to edit PKGBUILDs and other build files"
 msgstr "PKGBUILD ve diğer inşa dosyalarını düzenlemeyi sorma"
 
+#: pikaur/args.py:85
+#, fuzzy
+msgid "don't prompt to show the build files diff"
+msgstr "PKGBUILD ve diğer inşa dosyalarını düzenlemeyi sorma"
+
 #: pikaur/args.py:84
 msgid "don't remove build dir after the build"
 msgstr "inşa ettikten sonra inşa dizinini silme"
 
-#: pikaur/install_cli.py:601
+#: pikaur/install_cli.py:645
 msgid "edit"
 msgstr "düzenle"
 
-#: pikaur/install_cli.py:711
+#: pikaur/main.py:266
+#, fuzzy
+msgid "error"
+msgstr "hata:"
+
+#: pikaur/install_cli.py:753
 msgid "error:"
 msgstr "hata:"
 
-#: pikaur/install_cli.py:554
+#: pikaur/install_cli.py:582
 msgid "looking for conflicting packages..."
 msgstr "çakışan paketlere bakılıyor..."
 
-#: pikaur/install_cli.py:468
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:493
 msgid "m"
 msgstr "ç"
 
-#: pikaur/prompt.py:15
+#: pikaur/prompt.py:15 pikaur/install_cli.py:476
 msgid "n"
 msgstr "h"
 
-#: pikaur/install_cli.py:205
+#: pikaur/install_cli.py:230
 msgid "no editor found. Try setting $VISUAL or $EDITOR."
 msgstr "düzenleyici bulanamadı. $VISUAL veya $EDITOR değişkenini ayarlayın."
 
@@ -296,9 +312,10 @@ msgstr "düzenleyici bulanamadı. $VISUAL veya $EDITOR değişkenini ayarlayın.
 msgid "outofdate"
 msgstr "eski"
 
-#: pikaur/main.py:254
+#: pikaur/main.py:258
 msgid "pikaur requires systemd >= 235 (dynamic users) to be run as root."
-msgstr "pikaur root olabilmek için systemd >= 235 (dinamik kullanıcılar) gerektirir."
+msgstr ""
+"pikaur root olabilmek için systemd >= 235 (dinamik kullanıcılar) gerektirir."
 
 #: pikaur/args.py:76
 msgid "query packages from AUR only"
@@ -308,11 +325,11 @@ msgstr "paketler için sadece AUR'da sorgula"
 msgid "query packages from repository only"
 msgstr "paketler için sadece depoda sorgula"
 
-#: pikaur/install_cli.py:542
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:570
 msgid "r"
 msgstr "s"
 
-#: pikaur/install_cli.py:544
+#: pikaur/install_cli.py:565 pikaur/install_cli.py:572
 msgid "s"
 msgstr "a"
 
@@ -324,29 +341,30 @@ msgstr "sadece paket adlarında ara"
 msgid "sysupgrade '-git' and other dev packages older than 1 day"
 msgstr "1 günden eski sysupgrade '-git' ve diğer geliştirici paketleri"
 
-#: pikaur/install_cli.py:466
+#: pikaur/install_cli.py:476 pikaur/install_cli.py:491
 msgid "v"
 msgstr "g"
 
-#: pikaur/pprint.py:87 pikaur/install_cli.py:88 pikaur/install_cli.py:576
+#: pikaur/install_cli.py:91 pikaur/install_cli.py:604 pikaur/pprint.py:106
 msgid "warning:"
 msgstr "uyarı:"
 
-#: pikaur/prompt.py:14 pikaur/install_cli.py:464
+#: pikaur/prompt.py:14 pikaur/install_cli.py:476 pikaur/install_cli.py:489
 msgid "y"
 msgstr "e"
 
-#: pikaur/install_cli.py:663
+#: pikaur/install_cli.py:114
 #, python-brace-format
-msgid "{name} can't be built on the current arch ({arch}). Supported: {suparch}"
+msgid ""
+"{name} can't be built on the current arch ({arch}). Supported: {suparch}"
 msgstr "{name} bu mimaride inşa edilemez ({arch}). Destek: {suparch}"
 
-#: pikaur/install_cli.py:89
+#: pikaur/install_cli.py:92
 #, python-brace-format
 msgid "{name} {version} {package_source} package is up to date - skipping"
 msgstr "{name} {version} {package_source} paketi güncel - atlanıyor"
 
-#: pikaur/install_cli.py:276
+#: pikaur/install_cli.py:301
 #, python-brace-format
 msgid ""
 "{what} depends on: '{dep}'\n"
@@ -355,10 +373,10 @@ msgstr ""
 "{what} bağımlılığı: '{dep}'\n"
 "'{location}' konumunda: '{version}'"
 
-#: pikaur/build.py:339
+#: pikaur/build.py:345
 msgid "{} does not exist on the filesystem."
 msgstr "{} dosya sisteminde mevcut değil."
 
-#: pikaur/main.py:167
+#: pikaur/main.py:171
 msgid "{}: {}"
 msgstr "{}: {}"

--- a/pikaur/args.py
+++ b/pikaur/args.py
@@ -82,6 +82,7 @@ def cli_print_help(args: PikaurArgs) -> None:
             ('', '--namesonly', _("search only in package names")),
             ('', '--devel', _("sysupgrade '-git' and other dev packages older than 1 day")),
             ('-k', '--keepbuild', _("don't remove build dir after the build")),
+            ('', '--nodiff', _("don't prompt to show the build files diff")),
         ]
     print(''.join([
         '\n',
@@ -103,6 +104,7 @@ PIKAUR_OPTS = (
     ('a', 'aur'),
     (None, 'devel'),
     ('k', 'keepbuild'),
+    (None, 'nodiff')
 )
 
 

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -54,6 +54,10 @@ _CONFIG_SCHEMA = {
             'type': 'bool',
             'default': 'no',
         },
+        'NoDiff': {
+            'type': 'bool',
+            'default': 'no',
+        }
     },
     'colors': {
         'Version': {

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -682,7 +682,8 @@ class InstallPackagesCLI():
                     self.discard_aur_package(package_name)
                 continue
             if repo_status.build_files_updated and not self.args.noconfirm:
-                if self.ask_to_continue(
+                nodiff = self.args.nodiff or PikaurConfig().build.get('NoDiff')
+                if not nodiff and self.ask_to_continue(
                         _("Do you want to see build files {diff} for {name} package?").format(
                             diff=bold_line(_("diff")),
                             name=bold_line(', '.join(repo_status.package_names))


### PR DESCRIPTION
Added a configuration option to hide the prompt for the build files diff.
Similar to NoEdit, it can be set in the .conf file, as well as passed in as a flag, e.g "--nodiff"

fixes #147 