### PR TITLE
Feature request: Configurable git-diff context count for PKGBUILD comparison

### DIFF
--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -106,6 +106,10 @@ CONFIG_SCHEMA: Dict[str, Dict[str, Dict[str, str]]] = {
             'type': 'bool',
             'default': 'no'
         },
+        'DiffContext': {
+            'type': 'int',
+            'default': '3'
+        },
     },
     'misc': {
         'PacmanPath': {

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -554,6 +554,7 @@ class InstallPackagesCLI():
                         'diff',
                         '--ignore-space-change',
                         '--ignore-all-space',
+                        '--unified={line_count}'.format(line_count=PikaurConfig().ui.get_int('DiffContext')),
                         repo_status.last_installed_hash,
                         repo_status.current_hash,
                     ]


### PR DESCRIPTION
It would be nice if you could choose how many lines of diff context you want to see when comparing PKGBUILDs, rather than git-diff's default of 3 lines.