### PR TITLE
main: don't print empty upgradeable lines

### DIFF
--- a/pikaur/main.py
+++ b/pikaur/main.py
@@ -85,6 +85,8 @@ def cli_print_upgradeable() -> None:
         updates += aur_updates
     if not args.aur:
         updates += find_repo_upgradeable()
+    if not updates:
+        return
     if args.quiet:
         print_stdout('\n'.join([
             pkg_update.name for pkg_update in updates


### PR DESCRIPTION
If we try `pikaur -Qua | wc -l` on up-to-date system, we get `1` because of empty line. This fixes it.