### PR TITLE
add support to store signature file in package cache

### DIFF
--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Set, Optional, Any
 
 from .core import (
     DataType,
-    remove_dir, open_file, dirname,
+    remove_dir, replace_file, open_file, dirname,
     joined_spawn, spawn, interactive_spawn, InteractiveSpawn,
     sudo, running_as_root, isolate_root_cmd,
 )
@@ -391,16 +391,10 @@ class PackageBuild(DataType):
                 new_package_path = os.path.join(PACKAGE_CACHE_PATH, pkg_filename)
                 pkg_sig_path = pkg_path + ".sig"
                 new_package_sig_path = new_package_path + ".sig"
-                if os.path.exists(pkg_path):
-                    if not os.path.exists(PACKAGE_CACHE_PATH):
-                        os.makedirs(PACKAGE_CACHE_PATH)
-                    if os.path.exists(new_package_path):
-                        os.remove(new_package_path)
-                    shutil.move(pkg_path, PACKAGE_CACHE_PATH)
-                if os.path.exists(pkg_sig_path):
-                    if os.path.exists(new_package_sig_path):
-                        os.remove(new_package_sig_path)
-                    shutil.move(pkg_sig_path, PACKAGE_CACHE_PATH)
+                if not os.path.exists(PACKAGE_CACHE_PATH):
+                    os.makedirs(PACKAGE_CACHE_PATH)
+                replace_file(pkg_path, new_package_path)
+                replace_file(pkg_sig_path, new_package_sig_path)
                 pkg_path = new_package_path
             if pkg_path and os.path.exists(pkg_path):
                 self.built_packages_paths[pkg_name] = pkg_path

--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -389,12 +389,18 @@ class PackageBuild(DataType):
                 BuildError(_("{} does not exist on the filesystem.").format(pkg_path))
             if dest_dir == self.build_dir:
                 new_package_path = os.path.join(PACKAGE_CACHE_PATH, pkg_filename)
+                pkg_sig_path = pkg_path + ".sig"
+                new_package_sig_path = new_package_path + ".sig"
                 if os.path.exists(pkg_path):
                     if not os.path.exists(PACKAGE_CACHE_PATH):
                         os.makedirs(PACKAGE_CACHE_PATH)
                     if os.path.exists(new_package_path):
                         os.remove(new_package_path)
                     shutil.move(pkg_path, PACKAGE_CACHE_PATH)
+                if os.path.exists(pkg_sig_path):
+                    if os.path.exists(new_package_sig_path):
+                        os.remove(new_package_sig_path)
+                    shutil.move(pkg_sig_path, PACKAGE_CACHE_PATH)
                 pkg_path = new_package_path
             if pkg_path and os.path.exists(pkg_path):
                 self.built_packages_paths[pkg_name] = pkg_path

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -199,6 +199,13 @@ def open_file(
     )
 
 
+def replace_file(src: str, dest: str) -> None:
+    if os.path.exists(src):
+        if os.path.exists(dest):
+            os.remove(dest)
+        shutil.move(src, dest)
+
+
 def remove_dir(dir_path: str) -> None:
     try:
         shutil.rmtree(dir_path)


### PR DESCRIPTION
On some of my systems I also sign my own packages and verify the signatures - when copying over the package to the cache dir, the detached signature file is not copied over which leads to `pacman` failing to install the package.

This PR adds support to copy over the signature file if it exists in the build directory.