### PR TITLE
`[e] edit PKGBUILD` option when failing to build packages and Socks5Proxy option in the config file

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,6 +20,7 @@ depends=(
 )
 optdepends=(
 	'asp: for ABS support in -G/--getpkgbuild operation'
+	'python-pysocks: for socks5 proxy support'
 )
 conflicts=('pikaur')
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ to avoid asking for sudo password more than once
 Path to pacman executable.
 
 
+#### [network]
+
+##### Socks5Proxy (default: )
+Specify a socks5 proxy which is used to get AUR package information.
+
+The format is `[host[:port]]`, and the default port is 1080.
+SocksiPy socks module should be installed in order to use this option.
+
+Note that any downloads by `pacman`, `git` or `makepkg` will NOT use this proxy.
+If that's needed, setting proxy options in their own config files will take effect (such as `~/.gitconfig`, `~/.curlrc`).
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Path to pacman executable.
 Specify a socks5 proxy which is used to get AUR package information.
 
 The format is `[host[:port]]`, and the default port is 1080.
-SocksiPy socks module should be installed in order to use this option.
+PySocks module (`python-pysocks` package) should be installed in order to use this option.
 
 Note that any downloads by `pacman`, `git` or `makepkg` will NOT use this proxy.
 If that's needed, setting proxy options in their own config files will take effect (such as `~/.gitconfig`, `~/.curlrc`).

--- a/maintenance_scripts/vulture_whitelist.py
+++ b/maintenance_scripts/vulture_whitelist.py
@@ -22,6 +22,8 @@ whitelist.aur.AURPackageInfo.urlpath
 
 whitelist.build.PackageBuild._get_deps.deps_destination
 
+whitelist.main.socket.socket
+
 whitelist.news.MLStripper.convert_charrefs
 whitelist.news.MLStripper.handle_data
 whitelist.news.MLStripper.strict

--- a/pikaur.1
+++ b/pikaur.1
@@ -197,6 +197,17 @@ Interval in seconds in which \fBsudo\fR command will be spawned in the backgroun
 .SS "PacmanPath (default: pacman)"
 Path to pacman executable\.
 .
+.SS "[network]"
+.
+.SS "Socks5Proxy (default: )"
+Specify a socks5 proxy which is used to get AUR package information\.
+.
+.P
+The format is \fB[host[:port]]\fR, and the default port is 1080\. SocksiPy socks module should be installed in order to use this option\.
+.
+.P
+Note that any downloads by \fBpacman\fR, \fBgit\fR or \fBmakepkg\fR will NOT use this proxy\. If that\'s needed, setting proxy options in their own config files will take effect (such as \fB~/\.gitconfig\fR, \fB~/\.curlrc\fR)\.
+.
 .SH "Directories"
 .
 .nf

--- a/pikaur.1
+++ b/pikaur.1
@@ -203,7 +203,7 @@ Path to pacman executable\.
 Specify a socks5 proxy which is used to get AUR package information\.
 .
 .P
-The format is \fB[host[:port]]\fR, and the default port is 1080\. SocksiPy socks module should be installed in order to use this option\.
+The format is \fB[host[:port]]\fR, and the default port is 1080\. PySocks module (\fBpython\-pysocks\fR package) should be installed in order to use this option\.
 .
 .P
 Note that any downloads by \fBpacman\fR, \fBgit\fR or \fBmakepkg\fR will NOT use this proxy\. If that\'s needed, setting proxy options in their own config files will take effect (such as \fB~/\.gitconfig\fR, \fB~/\.curlrc\fR)\.

--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -28,7 +28,8 @@ from .pprint import (
     print_stdout, print_stderr, print_error,
 )
 from .prompt import (
-    retry_interactive_command_or_exit, ask_to_continue, get_input,
+    retry_interactive_command_or_exit, ask_to_continue,
+    get_input, get_editor_or_exit,
 )
 from .exceptions import (
     CloneError, DependencyError, BuildError, DependencyNotBuiltYet,
@@ -619,6 +620,7 @@ class PackageBuild(DataType):
                         _("[c] checksums skip"),
                         _("[i] ignore architecture"),
                         _("[d] delete build dir and try again"),
+                        _("[e] edit PKGBUILD"),
                         "-" * 24,
                         _("[s] skip building this package"),
                         _("[a] abort building all the packages"),
@@ -626,7 +628,7 @@ class PackageBuild(DataType):
                 )
                 answer = get_input(
                     prompt,
-                    _('r').upper() + _('p') + _('c') + _('i') + _('d') +
+                    _('r').upper() + _('p') + _('c') + _('i') + _('d') + _('e') +
                     _('s') + _('a')
                 )
 
@@ -644,6 +646,19 @@ class PackageBuild(DataType):
                 continue
             elif answer == _("d"):  # pragma: no cover
                 self.prepare_build_destination(flush=True)
+                continue
+            elif answer == _('e'):  # pragma: no cover
+                editor_cmd = get_editor_or_exit()
+                if editor_cmd:
+                    interactive_spawn(
+                        editor_cmd + [self.pkgbuild_path]
+                    )
+                    interactive_spawn(isolate_root_cmd([
+                        'cp',
+                        self.pkgbuild_path,
+                        os.path.join(self.build_dir, 'PKGBUILD')
+                    ]))
+                    # or self.prepare_build_destination(flush=True) ?
                 continue
             elif answer == _("a"):
                 raise SysExit(125)

--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -658,7 +658,6 @@ class PackageBuild(DataType):
                         self.pkgbuild_path,
                         os.path.join(self.build_dir, 'PKGBUILD')
                     ]))
-                    # or self.prepare_build_destination(flush=True) ?
                 continue
             elif answer == _("a"):
                 raise SysExit(125)

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -164,6 +164,12 @@ CONFIG_SCHEMA: Dict[str, Dict[str, Dict[str, str]]] = {
             'default': 'pacman'
         },
     },
+    'network': {
+        'Socks5Proxy': {
+            'type': 'str',
+            'default': '',
+        },
+    },
 }
 
 

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -33,12 +33,12 @@ from .print_department import (
 )
 from .core import (
     PackageSource,
-    interactive_spawn, remove_dir, open_file, sudo, get_editor, running_as_root,
+    interactive_spawn, remove_dir, open_file, sudo, running_as_root,
 )
 from .conflicts import find_aur_conflicts
 from .prompt import (
     ask_to_continue, retry_interactive_command,
-    retry_interactive_command_or_exit, get_input,
+    retry_interactive_command_or_exit, get_input, get_editor_or_exit
 )
 from .srcinfo import SrcInfo
 from .news import News
@@ -57,15 +57,6 @@ def hash_file(filename: str) -> str:  # pragma: no cover
             else:
                 eof = True
     return md5.hexdigest()
-
-
-def get_editor_or_exit() -> Optional[List[str]]:
-    editor = get_editor()
-    if not editor:
-        print_warning(_("no editor found. Try setting $VISUAL or $EDITOR."))
-        if not ask_to_continue(_("Do you want to proceed without editing?")):  # pragma: no cover
-            raise SysExit(125)
-    return editor
 
 
 class InstallPackagesCLI():

--- a/pikaur/main.py
+++ b/pikaur/main.py
@@ -87,9 +87,15 @@ def init_proxy() -> None:
             port = int(proxy[idx + 1:])
             proxy = proxy[:idx]
 
-        import socks  # type: ignore # pylint: disable=import-error
-        socks.set_default_proxy(socks.PROXY_TYPE_SOCKS5, proxy, port)  # type: ignore
-        socket.socket = socks.socksocket  # type: ignore
+        try:
+            import socks  # type: ignore
+            socks.set_default_proxy(socks.PROXY_TYPE_SOCKS5, proxy, port)
+            socket.socket = socks.socksocket  # type: ignore
+        except ImportError:
+            print_error(
+                _("pikaur requires python-pysocks to use a socks5 proxy.")
+            )
+            sys.exit(2)
 
 
 def cli_print_upgradeable() -> None:

--- a/pikaur/prompt.py
+++ b/pikaur/prompt.py
@@ -2,16 +2,16 @@
 
 import sys
 import tty
-from typing import List
+from typing import List, Optional
 
 from .args import parse_args
 from .config import PikaurConfig
 
-from .core import interactive_spawn
+from .core import interactive_spawn, get_editor
 from .i18n import _
 from .pprint import (
     color_line, print_stderr, get_term_width, range_printable,
-    PrintLock,
+    PrintLock, print_warning,
 )
 from .exceptions import SysExit
 
@@ -151,3 +151,12 @@ def retry_interactive_command_or_exit(cmd_args: List[str], **kwargs) -> None:
     if not retry_interactive_command(cmd_args, **kwargs):
         if not ask_to_continue(default_yes=False):
             raise SysExit(125)
+
+
+def get_editor_or_exit() -> Optional[List[str]]:
+    editor = get_editor()
+    if not editor:
+        print_warning(_("no editor found. Try setting $VISUAL or $EDITOR."))
+        if not ask_to_continue(_("Do you want to proceed without editing?")):  # pragma: no cover
+            raise SysExit(125)
+    return editor


### PR DESCRIPTION
### Add `[e] edit PKGBUILD` option when failing to build packages.

These days I managed to install ROS(`ros-melodic-desktop-full`) from AUR. Unforunately, it contains plenty of troublesome PKGBUILDs. But it's not very difficult to fix those mistakes in PKGBUILDs manually. So I added this option when build process isn't successful. It makes my installation much more flexible.

After editing PKGBUILD, the build directory isn't deleted and only the new PKGBUILD file is copyed to the build directory. Since only a small part of PKGBUILD was modified by me, there were no problems at all. But I'm not sure whether it is suitable. Maybe flushing the whole build directory is a better choice?

### Add Socks5Proxy option in the config file.

By setting `*_proxy` environment variables, it's easy to make `pikaur` work with a http/https proxy server. However, python's urllib will report an error if `*_proxy` environment variables start with `socks5://` or `socks5h://`, even with SocksiPy module installed. In order to solve this problem, I think it is necessary to add an option in the config file, which can make urllib use socks5 proxies. Of course, SocksiPy socks module is required to use this option.

Just as what I have written in README, any downloads by `pacman`, `git` or `makepkg` won't use this proxy. But I want `git` (cloning AUR packages) and `makepkg` (which will call `curl` to download files in most cases) to do so. Thus I managed to set proxy options in their own config files (`~/.gitconfig`, `~/.curlrc`).

Although it seems to work well now, I still hope that someone can propose a more elegant solution to the problem. I'll be very grateful.