### PR TITLE
Invoke python3 instead of python in PKDBUILD package() script.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -38,7 +38,7 @@ build() {
 
 package() {
 	cd "${srcdir}/${pkgname}" || exit 2
-	python setup.py install --prefix=/usr --root="$pkgdir/" --optimize=1
+	python3 setup.py install --prefix=/usr --root="$pkgdir/" --optimize=1
 	for langmo in $(cd ./locale && ls ./*.mo); do
 		lang=$(sed -e 's/.mo$//' <<< "${langmo}")
 		install -Dm644 "locale/${langmo}" "$pkgdir/usr/share/locale/${lang}/LC_MESSAGES/pikaur.mo"


### PR DESCRIPTION
Somehow I ended up with a python2 as my default python executable,
and it makes `makepkg -fsri` fail unnecessarily. Given that the
setup.py invocation won't work without Python 3, it shouldn't hurt
to explicitly require the correct version.