### PR TITLE
german l10n: fix clash between  edit PKGBUILD / remove builddir

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -466,7 +466,7 @@ msgstr "[c] git checkout -- '*'"
 
 #: pikaur/build.py:622
 msgid "[d] delete build dir and try again"
-msgstr "[e] entferne Build-Verzeichnis und versuche erneut"
+msgstr "[d] entferne Build-Verzeichnis und versuche erneut"
 
 #: pikaur/build.py:623
 msgid "[e] edit PKGBUILD"


### PR DESCRIPTION
In german, you cannot select "edit PKGBUILD" after a build fails, because its key clashes with "remove builddir and retry":

~~~
Ausführung des Befehls 'makepkg --force' ist fehlgeschlagen.
:: Versuchen, wiederherzustellen?
[R] Build nochmal versuchen
[p] überspringe PGP-Signaturprüfung
[c] überspringe Checksummen-Prüfung
[i] ignoriere Architektur
[e] entferne Build-Verzeichnis und versuche erneut
[e] edit PKGBUILD
------------------------
[u] überspringe Build dieses Pakets
[a] bauen aller Pakete abbrechen
> 
~~~

This reassigns one of them, so both options can be selected.

In general, it might be viable to use the same keys for all languages, instead of translating them.