### PR TITLE
added doas support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ AUR Host, useful for users in China to use "aur.tuna.tsinghua.edu.cn".
 ##### NewsUrl (default: https://www.archlinux.org/feeds/news/)
 Arch Linux News URL, useful for users of Parabola or other Arch derivatives.
 
+##### PrivilegeEscalationTool (default: sudo)
+A tool used to escalate user privileges. If using `doas` then `persistent` option is required in `doas.conf`. For example:
+```
+permit persist :wheel
+```
+Currently supported options are `sudo` and `doas`.
 
 #### [network]
 

--- a/pikaur.1
+++ b/pikaur.1
@@ -226,6 +226,9 @@ AUR Host, useful for users in China to use "aur\.tuna\.tsinghua\.edu\.cn"\.
 .SS "NewsUrl (default: https://www\.archlinux\.org/feeds/news/)"
 Arch Linux News URL, useful for users of Parabola or other Arch derivatives\.
 .
+.SS "PrivilegeEscalationTool (default: sudo)"
+A tool used to escalate user privileges. If using \fBdoas\fR option \fBpersistent\fR option is required in \fBdoas.conf\fR\. Currently supported options are \fBsudo\fR and \fBdoas\fR\.
+.
 .SS "[network]"
 .
 .SS "Socks5Proxy (default: )"

--- a/pikaur.1
+++ b/pikaur.1
@@ -227,7 +227,7 @@ AUR Host, useful for users in China to use "aur\.tuna\.tsinghua\.edu\.cn"\.
 Arch Linux News URL, useful for users of Parabola or other Arch derivatives\.
 .
 .SS "PrivilegeEscalationTool (default: sudo)"
-A tool used to escalate user privileges. If using \fBdoas\fR option \fBpersistent\fR option is required in \fBdoas.conf\fR\. Currently supported options are \fBsudo\fR and \fBdoas\fR\.
+A tool used to escalate user privileges\. If using \fBdoas\fR then \fBpersistent\fR option is required in \fBdoas\.conf\fR\. For example: \fBpermit persist :wheel\fR Currently supported options are \fBsudo\fR and \fBdoas\fR\.
 .
 .SS "[network]"
 .

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -174,6 +174,10 @@ CONFIG_SCHEMA: Dict[str, Dict[str, Dict[str, str]]] = {
         },
     },
     'misc': {
+        'UseDoas': {
+            'type': 'bool',
+            'default': 'no',
+        },
         'SudoLoopInterval': {
             'type': 'int',
             'default': '59',

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -174,10 +174,6 @@ CONFIG_SCHEMA: Dict[str, Dict[str, Dict[str, str]]] = {
         },
     },
     'misc': {
-        'UseDoas': {
-            'type': 'bool',
-            'default': 'no',
-        },
         'SudoLoopInterval': {
             'type': 'int',
             'default': '59',
@@ -193,6 +189,10 @@ CONFIG_SCHEMA: Dict[str, Dict[str, Dict[str, str]]] = {
         'NewsUrl': {
             'type': 'str',
             'default': 'https://www.archlinux.org/feeds/news/',
+        },
+        'PrivilegeEscalationTool': {
+            'type': 'str',
+            'default': 'sudo',
         },
     },
     'network': {

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -110,11 +110,10 @@ class InstallInfo(DataType):
 
 
 def sudo(cmd: List[str]) -> List[str]:
+    privilege_escalation_tool = PikaurConfig().misc.PrivilegeEscalationTool.get_str()
     if running_as_root():
         return cmd
-    if PikaurConfig().misc.UseDoas.get_bool():
-        return ['doas', ] + cmd
-    return ['sudo', ] + cmd
+    return [privilege_escalation_tool, ] + cmd
 
 
 def get_sudo_refresh_command() -> List[str]:

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -110,10 +110,9 @@ class InstallInfo(DataType):
 
 
 def sudo(cmd: List[str]) -> List[str]:
-    privilege_escalation_tool = PikaurConfig().misc.PrivilegeEscalationTool.get_str()
     if running_as_root():
         return cmd
-    return [privilege_escalation_tool, ] + cmd
+    return [PikaurConfig().misc.PrivilegeEscalationTool.get_str(), ] + cmd
 
 
 def get_sudo_refresh_command() -> List[str]:

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -112,6 +112,8 @@ class InstallInfo(DataType):
 def sudo(cmd: List[str]) -> List[str]:
     if running_as_root():
         return cmd
+    if PikaurConfig().misc.UseDoas.get_bool():
+        return ['doas', ] + cmd
     return ['sudo', ] + cmd
 
 

--- a/pikaur/main.py
+++ b/pikaur/main.py
@@ -350,14 +350,10 @@ def check_runtime_deps(dep_names: Optional[List[str]] = None) -> None:
         )
         sys.exit(65)
     if not dep_names:
-        if PikaurConfig().misc.UseDoas.get_bool():
-            dep_names = [
-                "fakeroot",
-            ] + (['doas'] if not running_as_root() else [])
-        else:
-            dep_names = [
-                "fakeroot",
-            ] + (['sudo'] if not running_as_root() else [])
+        privilege_escalation_tool = PikaurConfig().misc.PrivilegeEscalationTool.get_str()
+        dep_names = ["fakeroot", ] + (
+            [privilege_escalation_tool] if not running_as_root() else []
+        )
 
     for dep_bin in dep_names:
         if not shutil.which(dep_bin):

--- a/pikaur/main.py
+++ b/pikaur/main.py
@@ -350,9 +350,16 @@ def check_runtime_deps(dep_names: Optional[List[str]] = None) -> None:
         )
         sys.exit(65)
     if not dep_names:
-        dep_names = [
-            "fakeroot",
-        ] + (['sudo'] if not running_as_root() else [])
+        if PikaurConfig().misc.UseDoas.get_bool():
+            dep_names = [
+                "fakeroot",
+            ] + (['doas'] if not running_as_root() else [])
+        else:
+            dep_names = [
+                "fakeroot",
+            ] + (['sudo'] if not running_as_root() else [])
+ 
+
     for dep_bin in dep_names:
         if not shutil.which(dep_bin):
             print_error("'{}' {}.".format(

--- a/pikaur/main.py
+++ b/pikaur/main.py
@@ -358,7 +358,6 @@ def check_runtime_deps(dep_names: Optional[List[str]] = None) -> None:
             dep_names = [
                 "fakeroot",
             ] + (['sudo'] if not running_as_root() else [])
- 
 
     for dep_bin in dep_names:
         if not shutil.which(dep_bin):


### PR DESCRIPTION
I've added [opendoas](https://www.archlinux.org/packages/community/x86_64/opendoas/) support.
With how it is implemented right now it depends on doas.conf having "persist" option.
An example would be:
`permit persist :wheel`