### PR TITLE
fix(install cli): ignore 'search' on aur package install

### DIFF
--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -966,6 +966,7 @@ class InstallPackagesCLI():
                             'sysupgrade',
                             'refresh',
                             'ignore',
+                            'search',
                         ]) + list(aur_packages_to_install.values())
                     ),
                     pikspect=True,


### PR DESCRIPTION
pacman fails with "error: invalid option '--search'", when invoking pikaur like 'pikaur -s packagename'