### PR TITLE
Make shown package information table aligned correctly even if there are full-width characters

### DIFF
--- a/pikaur/info_cli.py
+++ b/pikaur/info_cli.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from multiprocessing.pool import ThreadPool
+from unicodedata import east_asian_width
 
 from .i18n import _
 from .aur import find_aur_packages, get_all_aur_names
@@ -72,9 +73,19 @@ def cli_info_packages() -> None:
                 value = datetime.fromtimestamp(value).strftime('%c')
             elif isinstance(value, list):
                 value = ', '.join(value) or _("None")
-            pkg_info_lines.append('{key:26}: {value}'.format(
-                key=bold_line(display_name), value=value))
+            pkg_info_lines.append('{key}: {value}'.format(
+                key=_rightpad(bold_line(display_name), 26), value=value))
         print(
             _decorate_info_output('\n'.join(pkg_info_lines)) +
             ('\n' if i + 1 < num_found else '')
         )
+
+
+def _rightpad(text: str, num: int) -> str:
+    space = num
+    for i in text:
+        if east_asian_width(i) in ["F", "W", "A"]:
+            space -= 2
+        else:
+            space -= 1
+    return text + " " * space


### PR DESCRIPTION
The right-padding that just counts the number of characters doesn't work well with full-width characters, and the displayed table sometimes becomes corrupted(See the image below). This PR is a workaround for this problem.

### Before ###
![pikaur_before](https://user-images.githubusercontent.com/58389750/83033691-6639c780-a072-11ea-889b-d1bccb8bc040.png)

### After ###
![pikaur_after](https://user-images.githubusercontent.com/58389750/83033732-70f45c80-a072-11ea-8fb0-48dd48831202.png)
