### PR TITLE
Add more fallback editors to core.py

### DIFF
--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -278,8 +278,8 @@ def get_editor() -> Optional[List[str]]:
         return editor_line.split(' ')
     for editor in (
             'vim', 'nano', 'mcedit', 'edit', 'emacs', 'nvim', 'kak',
-            'e3', 'atom', 'adie', 'dedit', 'gedit', 'jedit', 'kate', 'kwrite', 'leafpad', 'mousepad',
-            'notepadqq', 'pluma', 'code', 'xed', 'nvim-qt', 'geany',
+            'e3', 'atom', 'adie', 'dedit', 'gedit', 'jedit', 'kate', 'kwrite', 'leafpad',
+            'mousepad', 'notepadqq', 'pluma', 'code', 'xed', 'nvim-qt', 'geany',
     ):
         path = shutil.which(editor)
         if path:

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -276,7 +276,11 @@ def get_editor() -> Optional[List[str]]:
     editor_line = os.environ.get('VISUAL') or os.environ.get('EDITOR')
     if editor_line:
         return editor_line.split(' ')
-    for editor in ('vim', 'nano', 'mcedit', 'edit', 'emacs', 'e3', 'atom', 'adie', 'dedit', 'gedit', 'jedit', 'kate', 'kwrite', 'leafpad', 'mousepad', 'notepadqq', 'pluma', 'code', 'xed', 'kak', 'nvim', 'nvim-qt', 'geany'):
+    for editor in (
+            'vim', 'nano', 'mcedit', 'edit', 'emacs',
+            'e3', 'atom', 'adie', 'dedit', 'gedit', 'jedit', 'kate', 'kwrite', 'leafpad', 'mousepad',
+            'notepadqq', 'pluma', 'code', 'xed', 'kak', 'nvim', 'nvim-qt', 'geany',
+    ):
         path = shutil.which(editor)
         if path:
             return [path, ]

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -277,9 +277,9 @@ def get_editor() -> Optional[List[str]]:
     if editor_line:
         return editor_line.split(' ')
     for editor in (
-            'vim', 'nano', 'mcedit', 'edit', 'emacs',
+            'vim', 'nano', 'mcedit', 'edit', 'emacs', 'nvim', 'kak',
             'e3', 'atom', 'adie', 'dedit', 'gedit', 'jedit', 'kate', 'kwrite', 'leafpad', 'mousepad',
-            'notepadqq', 'pluma', 'code', 'xed', 'kak', 'nvim', 'nvim-qt', 'geany',
+            'notepadqq', 'pluma', 'code', 'xed', 'nvim-qt', 'geany',
     ):
         path = shutil.which(editor)
         if path:

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -276,7 +276,7 @@ def get_editor() -> Optional[List[str]]:
     editor_line = os.environ.get('VISUAL') or os.environ.get('EDITOR')
     if editor_line:
         return editor_line.split(' ')
-    for editor in ('vim', 'nano', 'mcedit', 'edit'):
+    for editor in ('vim', 'nano', 'mcedit', 'edit', 'emacs', 'e3', 'atom', 'adie', 'dedit', 'gedit', 'jedit', 'kate', 'kwrite', 'leafpad', 'mousepad', 'notepadqq', 'pluma', 'code', 'xed', 'kak', 'nvim', 'nvim-qt', 'geany'):
         path = shutil.which(editor)
         if path:
             return [path, ]


### PR DESCRIPTION
In response to Issue #540, added most of the popular text editors into the get_editor() function in pikaur/core.py.