### PR TITLE
avoid make bug with directories in $PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ POTEMPFILES := $(addprefix $(LOCALEDIR)/,$(addsuffix .po~,$(LANGS)))
 MOFILES = $(POFILES:.po=.mo)
 DISTDIR := dist
 
-PIKAMAN := python ./maintenance_scripts/pikaman.py
+PIKAMAN := $(shell which python) ./maintenance_scripts/pikaman.py
 README_FILE := README.md
 MAN_FILE := pikaur.1
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ POTEMPFILES := $(addprefix $(LOCALEDIR)/,$(addsuffix .po~,$(LANGS)))
 MOFILES = $(POFILES:.po=.mo)
 DISTDIR := dist
 
+# A $(which python) is necessary here to avoid a bug in make that would
+# try to execute a directory named "python". See https://savannah.gnu.org/bugs/?57962
 PIKAMAN := $(shell which python) ./maintenance_scripts/pikaman.py
 README_FILE := README.md
 MAN_FILE := pikaur.1


### PR DESCRIPTION
Make 4.3 (up to at least 4.3.3) has a bug where it will attempt to execute a directory in $PATH (https://savannah.gnu.org/bugs/?57962). This fix ensures that only the python executable will be used to run pikaman.py.

Fixes #535.