### PR TITLE
Add instructions for migrating from Yay

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,15 @@ checkupdates ; pikaur -Qua 2>/dev/null
 
 If you find the command takes a long time to initialize, make sure to periodically clear your cache: `pikaur -Scc`. Root pikaur is using SystemD Dynamic Users to isolate build process from the root, and it takes some time to change the owner of build cache to dynamic temporary user.
 
+##### How to migrate from Yay?
+
+This will migrate the cache of what AUR packages have been installed, so you can still see a Git diff for the next update of each package:
+
+```sh
+mv ~/.cache/yay/* ~/.local/share/pikaur/aur_repos/
+find ~/.local/share/pikaur/aur_repos -mindepth 1 -maxdepth 1 -type d | xargs -r -I '{}' -- sh -c 'cd "{}" && git rev-parse HEAD > last_installed.txt'
+```
+
 
 
 ## Contributing


### PR DESCRIPTION
After switching from Yay this afternoon, I noticed a lack of Git diffs when updating AUR packages I'd installed previously. From installing those updates, I found where pikaur stores its cache, and that each one had a `last_installed.txt` containing a Git SHA.

I tried just moving the directories, but from installing some new updates tonight, determined that `last_installed.txt` was indeed necessary.

I'm not certain this correctly covers all cases, given how a bunch of packages have uncommitted changes that Yay must have made in its updating of Git-based packages, e.g.:

```diff
diff --git a/PKGBUILD b/PKGBUILD
index ed0e32b..6079d1f 100644
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: David Cristofaro <david@dtcristo.com>
 pkgname=lucky-git
-pkgver=0.22.0.r13.1fb6e57
+pkgver=0.24.0.r2.3258f54
 pkgrel=1
 pkgdesc='A web framework written in Crystal'
 arch=('x86_64')
```