### PR TITLE
Add IgnoreArch config option to [build]

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Always skip the build if it fails and don't show recovery prompt.
 Always isolate the build using systemd dynamic users.
 Will be overridden by `--dynamic-users` flag.
 
+##### IgnoreArch (default: no)
+Ignore specified architectures (`arch`-array) in PKGBUILDs.
+
 
 #### [review]
 

--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -148,6 +148,7 @@ class PackageBuild(DataType):
         self.keep_build_dir = self.args.keepbuild or (
             is_devel_pkg(self.package_base) and PikaurConfig().build.KeepDevBuildDir.get_bool()
         )
+        self.skip_carch_check = PikaurConfig().build.IgnoreArch.get_bool()
 
         if os.path.exists(self.repo_path):
             # pylint: disable=simplifiable-if-statement
@@ -594,6 +595,9 @@ class PackageBuild(DataType):
         PackageDB.discard_local_cache()
 
     def check_pkg_arch(self) -> None:
+        if self.skip_carch_check:
+            return
+
         src_info = SrcInfo(pkgbuild_path=self.pkgbuild_path)
         arch = MakepkgConfig.get('CARCH')
         supported_archs = src_info.get_values('arch')

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -131,6 +131,10 @@ CONFIG_SCHEMA: Dict[str, Any] = {
                 'option': 'GitDiffArgs',
             },
         },
+        'IgnoreArch': {
+            'type': 'bool',
+            'default': 'no'
+        },
     },
     'review': {
         'NoEdit': {


### PR DESCRIPTION
This adds an option `IgnoreArch` to the `[build]`-section of the configuration file, which defaults to `no`. When set to `yes`, all warnings and prompts regarding architecture mismatches between the host system and the `arch`-array in the PKGBUILD will be skipped and `--ignorearch` will be passed to `makepkg` when building the package.

I started patching this before I noticed that the "error" about an architecture mismatch is really more of a warning prompt, and `--noconfirm` will accept the prompt and simply continue -- I originally expected this to abort the sync process or skip updating the package. As it stands, this setting isn't strictly _necessary_ for my own use after this discovery, but I thought maybe still useful enough to be merged.