### PR TITLE
Fix zsh completion unnecessarily fetching packages when completing sync options.

### DIFF
--- a/packaging/usr/share/zsh/site-functions/_pikaur
+++ b/packaging/usr/share/zsh/site-functions/_pikaur
@@ -79,7 +79,7 @@ _pikaur_completions_all_packages() {
 		typeset -U packages
 		${seq} _wanted repo_packages expl "repository/package" compadd ${sep[@]} ${(@)packages}
 	else
-		packages=( $(_call_program packages $cmd[@] -Ssq) )
+		packages=( $(_call_program packages $cmd[@] --namesonly -Ssq ${words[CURRENT]}) )
 		typeset -U packages
 		${seq} _wanted packages expl "packages" compadd ${sep[@]} - "${(@)packages}"
 

--- a/packaging/usr/share/zsh/site-functions/_pikaur
+++ b/packaging/usr/share/zsh/site-functions/_pikaur
@@ -99,6 +99,8 @@ _pikaur_action_sync() {
 		state=sync_search
 	elif (( $+words[(r)--search] )); then
 		state=sync_search
+	elif [[ ${words[CURRENT][1]} == '-' ]]; then
+		state=sync_opts
 	fi
 
 	case $state in
@@ -108,6 +110,13 @@ _pikaur_action_sync() {
 				"$_pacman_opts_sync_modifiers[@]" \
 				"$_pikaur_opts_sync_search_modifiers[@]" \
 				'*:search text: '
+			;;
+		sync_opts)
+			_arguments -s : \
+				"$_pacman_opts_common[@]" \
+				"$_pacman_opts_sync_actions[@]" \
+				"$_pacman_opts_sync_modifiers[@]" \
+				"$_pikaur_opts_sync_modifiers[@]"
 			;;
 		*)
 			_arguments -s : \


### PR DESCRIPTION
**What's in the PR:**

Tab-completion fix and optimization for ZSH. 

Change 1: The autocompletion script no longer attempts to autocomplete with package names when the current argument looks like an option: i.e. starts with `-` (dash).

There is a significant performance improvement with autocompletion. This fixes #545.

New (Pressing Tab starts recording, so each loop starts right after Tab is pressed):
![](https://i.imgur.com/ga66YBq.gif)

Old:
![](https://i.imgur.com/TTrtqkz.gif)

Change 2: When autocompleting package names, pass current argument as query term into `pikaur -Ssq`, and also now uses `--namesonly` so it would only query the names. I notice a small improvement this way, although it still takes a while. See GIF as well.

New:
![](https://i.imgur.com/ApIexCE.gif)

Old:
![](https://i.imgur.com/vIpe4zn.gif)

I'm not sure how to measure zsh-completion using `time` as it's not a program on its own, so I hope the gifs are OK, let me know if there's a way to better measure this.

**Hacktoberfest participation:**

I am currently participating in [Hacktoberfest](https://hacktoberfest.digitalocean.com/). If you're willing, it would help me if you kindly add `hacktoberfest-accepted` label to this PR. No questions asked if you choose to not opt in :)

Regards,

Naufal