### PR TITLE
Handle open issue 448 by raising an exception

### DIFF
--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -204,7 +204,11 @@ def isolate_root_cmd(cmd: List[str], cwd=None) -> List[str]:
     ):
         if os.environ.get(env_var_name) is not None:
             base_root_isolator += ['-E', f'{env_var_name}={os.environ[env_var_name]}']
-    if cmd == ['makepkg','--printsrcinfo','-p','PKGBUILD']:
+    # systemd-run does not like pikaur -P - see issue 448
+    # this is only a workaround for now to prevent the error from arising.
+    # It's more elegent to copy the directory with PKGBUILD into /var/cache/private/pikaur
+    # @TODO - write code to do this.
+    if cmd == ['makepkg', '--printsrcinfo', '-p', 'PKGBUILD']:
         raise Exception("Please run pikaur -P as a standard user")
     return base_root_isolator + cmd
 

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -204,6 +204,8 @@ def isolate_root_cmd(cmd: List[str], cwd=None) -> List[str]:
     ):
         if os.environ.get(env_var_name) is not None:
             base_root_isolator += ['-E', f'{env_var_name}={os.environ[env_var_name]}']
+    if cmd == ['makepkg','--printsrcinfo','-p','PKGBUILD']:
+        raise Exception("Please run pikaur -P as a standard user")
     return base_root_isolator + cmd
 
 


### PR DESCRIPTION
Solves https://github.com/actionless/pikaur/issues/448 by raising an exception when pikaur -P calls makepkg --printsrcinfo -p PKGBUILD via systemd-run. Perhaps not the most elegant solution.