### PR TITLE
start checking if aur packages are orphaned

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -354,7 +354,7 @@ max-attributes=16
 max-bool-expr=5
 
 # Maximum number of branch for function / method body
-max-branches=13
+max-branches=12
 
 # Maximum number of locals for function / method body
 max-locals=15

--- a/.pylintrc
+++ b/.pylintrc
@@ -354,7 +354,7 @@ max-attributes=16
 max-bool-expr=5
 
 # Maximum number of branch for function / method body
-max-branches=12
+max-branches=13
 
 # Maximum number of locals for function / method body
 max-locals=15

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -92,6 +92,7 @@ class InstallInfo(DataType):
     current_version: str
     new_version: str
     description: Optional[str] = None
+    maintainer: Optional[str] = None
     repository: Optional[str] = None
     devel_pkg_age_days: Optional[int] = None
     package: Union['pyalpm.Package', 'AURPackageInfo']

--- a/pikaur/install_info_fetcher.py
+++ b/pikaur/install_info_fetcher.py
@@ -447,6 +447,7 @@ class InstallInfoFetcher(ComparableType):
                     new_version=aur_pkg.version,
                     description=aur_pkg.desc,
                     package=aur_pkg,
+                    maintainer=maintainer,
                     pkgbuild_path=path,
                 )
         self.aur_updates_install_info += list(aur_updates_install_info_by_name.values())

--- a/pikaur/install_info_fetcher.py
+++ b/pikaur/install_info_fetcher.py
@@ -406,6 +406,7 @@ class InstallInfoFetcher(ComparableType):
                 current_version=local_pkg.version if local_pkg else ' ',
                 new_version=aur_pkg.version,
                 description=aur_pkg.desc,
+                maintainer=aur_pkg.maintainer,
                 package=aur_pkg,
             )
         for pkg_name in list(aur_updates_install_info_by_name.keys())[:]:
@@ -447,7 +448,6 @@ class InstallInfoFetcher(ComparableType):
                     new_version=aur_pkg.version,
                     description=aur_pkg.desc,
                     package=aur_pkg,
-                    maintainer=maintainer,
                     pkgbuild_path=path,
                 )
         self.aur_updates_install_info += list(aur_updates_install_info_by_name.values())
@@ -492,6 +492,7 @@ class InstallInfoFetcher(ComparableType):
                 current_version=local_pkg.version if local_pkg else ' ',
                 new_version=aur_pkg.version,
                 description=aur_pkg.desc,
+                maintainer=aur_pkg.maintainer,
                 package=aur_pkg,
             ))
 

--- a/pikaur/print_department.py
+++ b/pikaur/print_department.py
@@ -129,7 +129,7 @@ def pretty_format_upgradeable(  # pylint: disable=too-many-statements
 
     SortKey = Union[Tuple, str]
 
-    def pretty_format(pkg_update: 'InstallInfo') -> Tuple[str, SortKey]:  # pylint:disable=too-many-locals
+    def pretty_format(pkg_update: 'InstallInfo') -> Tuple[str, SortKey]:  # pylint:disable=too-many-locals,R0912
         common_version, diff_weight = get_common_version(
             pkg_update.current_version or '', pkg_update.new_version or ''
         )

--- a/pikaur/print_department.py
+++ b/pikaur/print_department.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 GROUP_COLOR = 4
 REPLACEMENTS_COLOR = 14
+ORPHANED_COLOR = 9
 
 
 AnyPackage = Union[AURPackageInfo, pyalpm.Package]
@@ -225,6 +226,14 @@ def pretty_format_upgradeable(  # pylint: disable=too-many-statements
         days_old = ''
         if pkg_update.devel_pkg_age_days:
             days_old = ' ' + _('({} days old)').format(pkg_update.devel_pkg_age_days)
+
+        if (
+                isinstance(pkg_update.package, AURPackageInfo) and
+                pkg_update.package.maintainer is None
+        ):
+            orphaned = ' [orphaned]'
+            pkg_len += len(orphaned)
+            pkg_name += _color_line(orphaned, ORPHANED_COLOR)
 
         out_of_date = ''
         if (

--- a/pikaur/print_department.py
+++ b/pikaur/print_department.py
@@ -231,7 +231,7 @@ def pretty_format_upgradeable(  # pylint: disable=too-many-statements
                 isinstance(pkg_update.package, AURPackageInfo) and
                 pkg_update.package.maintainer is None
         ):
-            orphaned = ' [orphaned]'
+            orphaned = f" [{_('orphaned')}]"
             pkg_len += len(orphaned)
             pkg_name += _color_line(orphaned, ORPHANED_COLOR)
 


### PR DESCRIPTION
Solves #544 by making a check for the `maintainer` field of a package from the AUR