### PR TITLE
chore: explicitly rebuild from AUR

### DIFF
--- a/packaging/usr/bin/pikaur
+++ b/packaging/usr/bin/pikaur
@@ -26,9 +26,9 @@ except ModuleNotFoundError:
     else:
         print_warning()
         print_warning(_('System Python had minor version update. You need to rebuild Pikaur:'))
-        print_warning('    pikaur -S --rebuild pikaur')
+        print_warning('    pikaur -S --rebuild aur/pikaur')
         print_warning(_('or'))
-        print_warning('    pikaur -S --rebuild pikaur-git')
+        print_warning('    pikaur -S --rebuild aur/pikaur-git')
         print_warning()
 
 


### PR DESCRIPTION
This is useful when the user has a third-party binary repository containing pikaur but wasn't rebuilt for the new system Python, probably because of a delay or the user having [testing] enabled. It is also harmless otherwise.