### PR TITLE
fix(search_cli): use different terminal escape sequence (fixes #497)

### DIFF
--- a/pikaur/search_cli.py
+++ b/pikaur/search_cli.py
@@ -139,7 +139,7 @@ def cli_search_packages(enumerated=False) -> List[AnyPackage]:  # pylint: disabl
     if not args.quiet:
         progressbar_length = max(len(search_query), 1) + (not REPO_ONLY) + (not AUR_ONLY)
         print_stderr(_("Searching... [{bar}]").format(bar='-' * progressbar_length), end='')
-        print_stderr('\x1b[\bb' * (progressbar_length + 1), end='')
+        print_stderr('\x1b[1D' * (progressbar_length + 1), end='')
 
     with ThreadPool() as pool:
         request_local = pool.apply_async(package_search_thread_local, ())


### PR DESCRIPTION
Apply the same change to search_cli, that was previously applied to the progressbar.
The other change can be seen here: b0f54b1bcd2ad5ce1230f05d3d505c963a7e5cb7