### PR TITLE
Fix #627

### DIFF
--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -315,6 +315,7 @@ class InstallPackagesCLI():
         if not (
                 self.install_info.repo_packages_install_info or
                 self.install_info.new_repo_deps_install_info or
+                self.install_info.new_thirdparty_repo_deps_install_info or
                 self.install_info.thirdparty_repo_packages_install_info or
                 self.install_info.aur_updates_install_info
         ):


### PR DESCRIPTION
Fixes #627

For new packages, this line adds the `InstallInfo` to `new_thirdparty_repo_deps_install_info`

https://github.com/actionless/pikaur/blob/e96206fa6c61b7e123985759ae890def4b7e76c2/pikaur/install_info_fetcher.py#L332

Later, when we check whether we have anything to install, It was not handled/checked:

https://github.com/actionless/pikaur/blob/e96206fa6c61b7e123985759ae890def4b7e76c2/pikaur/install_cli.py#L314-L320

So installing pfetch-git using `pikaur -S pfetch` will say "Nothing to do", as the it didn't check `new_thirdparty_repo_deps_install_info` for any packages.

> More: **Line 289 of this file may require same condition to be added**, didn't modify it since I am not sure

PS: I tried fixing the issue i faced myself, it was one line change, though it should be reviewed by someone with better knowledge of the logic preferably : )

## Change in behaviour

<img width="75%" src="https://user-images.githubusercontent.com/37269665/152943646-295ed1b6-46fa-4a1e-aa46-e7a2fa9640d0.png" />

