### PR TITLE
doc: remove tuna aur config for China users

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Currently supported options are `sudo` and `doas`.
 #### [network]
 
 ##### AurUrl (default: https://aur.archlinux.org)
-AUR Host, useful for users in China to use `https://aur.tuna.tsinghua.edu.cn`.
+AUR Host.
 
 ##### NewsUrl (default: https://www.archlinux.org/feeds/news/)
 Arch Linux News URL, useful for users of Parabola or other Arch derivatives.


### PR DESCRIPTION
Tuna has removed the aur proxy service since 01Mar:
- https://mirrors.tuna.tsinghua.edu.cn/news/remove-aur/
- https://github.com/tuna/issues/issues/1424
- ping: aur.tuna.tsinghua.edu.cn: Name or service not known