### PR TITLE
fix(install_cli: review_build_files): use dynamic user for git diff (fixes #645)

### DIFF
--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -34,7 +34,7 @@ from .print_department import (
 )
 from .core import (
     PackageSource,
-    interactive_spawn, remove_dir, open_file, sudo, running_as_root,
+    interactive_spawn, remove_dir, open_file, sudo, running_as_root, isolate_root_cmd
 )
 from .conflicts import find_aur_conflicts
 from .prompt import (
@@ -781,7 +781,7 @@ class InstallPackagesCLI():
                             git_args += [
                                 f':(exclude){file_path}',
                             ]
-                    interactive_spawn(git_args)
+                    interactive_spawn(isolate_root_cmd(git_args))
             elif self.args.noconfirm:
                 print_stdout(_skip_diff_label.format(
                     pkg=_pkg_label,


### PR DESCRIPTION
As mentioned in https://github.com/actionless/pikaur/issues/645#issuecomment-1123902667 git 2.35.2 refuses to run if the repository belongs to a different user. Also see [safe.directory](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory).

This fix will run `git diff` as pikaur Dynamic User. Caveat is that it will also lose the users custom git settings.