### PR TITLE
feat(print_dept): add printing message of package total size

### DIFF
--- a/pikaur/install_info_fetcher.py
+++ b/pikaur/install_info_fetcher.py
@@ -616,3 +616,16 @@ class InstallInfoFetcher(ComparableType):
                             dep_install_info.provided_by = None
                             dep_install_info.name = name
                             dep_install_info.new_version = dep_install_info.package.version
+
+    def get_total_size(self) -> Dict[str, float]:
+        total_download_size = 0.0
+        total_installed_size = 0.0
+        for pkg_update in (
+                self.repo_packages_install_info + self.thirdparty_repo_packages_install_info
+        ):
+            total_download_size += pkg_update.package.size / 1024 ** 2
+            total_installed_size += pkg_update.package.isize / 1024 ** 2
+        return {
+            "total_download_size": total_download_size,
+            "total_installed_size": total_installed_size
+        }

--- a/pikaur/install_info_fetcher.py
+++ b/pikaur/install_info_fetcher.py
@@ -1,5 +1,5 @@
 """ This file is licensed under GPLv3, see https://www.gnu.org/licenses/ """
-
+from itertools import chain
 from multiprocessing.pool import ThreadPool
 from typing import List, Optional, Dict, Any, Sequence, Union
 
@@ -617,15 +617,14 @@ class InstallInfoFetcher(ComparableType):
                             dep_install_info.name = name
                             dep_install_info.new_version = dep_install_info.package.version
 
-    def get_total_size(self) -> Dict[str, float]:
+    def get_total_download_size(self) -> float:
         total_download_size = 0.0
+        for install_info in chain.from_iterable(self.repo_install_info):
+            total_download_size += install_info.package.size / 1024 ** 2
+        return total_download_size
+
+    def get_total_installed_size(self) -> float:
         total_installed_size = 0.0
-        for pkg_update in (
-                self.repo_packages_install_info + self.thirdparty_repo_packages_install_info
-        ):
-            total_download_size += pkg_update.package.size / 1024 ** 2
-            total_installed_size += pkg_update.package.isize / 1024 ** 2
-        return {
-            "total_download_size": total_download_size,
-            "total_installed_size": total_installed_size
-        }
+        for install_info in chain.from_iterable(self.repo_install_info):
+            total_installed_size += install_info.package.isize / 1024 ** 2
+        return total_installed_size

--- a/pikaur/print_department.py
+++ b/pikaur/print_department.py
@@ -448,7 +448,15 @@ def pretty_format_sysupgrade(
             new_aur_deps,
             verbose=verbose, color=color, print_repo=False
         ))
-    result += ['']
+    if PikaurConfig().sync.ShowDownloadSize.get_bool():
+        result.append(
+            f'\n{_bold_line("Total Download Size:")}'
+            f'{str(round(install_info.get_total_size()["total_download_size"], 2)).rjust(10)} MiB'
+            f'\n{_bold_line("Total Installed Size:")}'
+            f'{str(round(install_info.get_total_size()["total_installed_size"], 2)).rjust(9)} MiB\n'
+        )
+    else:
+        result += ['']
     return '\n'.join(result)
 
 

--- a/pikaur/print_department.py
+++ b/pikaur/print_department.py
@@ -451,9 +451,9 @@ def pretty_format_sysupgrade(
     if PikaurConfig().sync.ShowDownloadSize.get_bool():
         result.append(
             f'\n{_bold_line("Total Download Size:")}'
-            f'{str(round(install_info.get_total_size()["total_download_size"], 2)).rjust(10)} MiB'
+            f'{str(round(install_info.get_total_download_size(), 2)).rjust(10)} MiB'
             f'\n{_bold_line("Total Installed Size:")}'
-            f'{str(round(install_info.get_total_size()["total_installed_size"], 2)).rjust(9)} MiB\n'
+            f'{str(round(install_info.get_total_installed_size(), 2)).rjust(9)} MiB\n'
         )
     else:
         result += ['']


### PR DESCRIPTION
https://github.com/actionless/pikaur/issues/659

If the option **VerbosePkgLists** is off, the total size info will also be printed, so it seems not related, use the below option instead.

```
[sync]
showdownloadsize = yes
```
---
pacman:
```
➜  ~ sudo pacman -S pikaur
warning: pikaur-1.11-1 is up to date -- reinstalling
resolving dependencies...
looking for conflicting packages...

Package (1)         Old Version  New Version  Net Change  Download Size

archlinuxcn/pikaur  1.11-1       1.11-1         0.00 MiB       0.22 MiB

Total Download Size:      0.22 MiB
Total Installed Size:     1.06 MiB
Net Upgrade Size:         0.00 MiB

:: Proceed with installation? [Y/n]
```
---
pikaur with `showdownloadsize = no`:
```
➜  ~ ./Projects/linweiyuan/pikaur/pikaur.py -S pikaur
Reading repository package databases...
Reading local package database...

:: Third-party repository package will be installed:
 archlinuxcn/pikaur                    1.11-1               -> 1.11-1

:: Proceed with installation? [Y/n] 
:: [v]iew package details   [m]anually select packages
>> 
```

pikaur with `showdownloadsize = yes`:
```
➜  ~ ./Projects/linweiyuan/pikaur/pikaur.py -S pikaur
Reading repository package databases...
Reading local package database...

:: Third-party repository package will be installed:
 archlinuxcn/pikaur                    1.11-1               -> 1.11-1              0.22 MiB

Total Download Size:      0.22 MiB
Total Installed Size:     1.06 MiB

:: Proceed with installation? [Y/n] 
:: [v]iew package details   [m]anually select packages
>> 
```
