### PR TITLE
Update to pass GNUPGHOME environmental variable as part of makepkg builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ When doing sysupgrade ignore AUR packages which have `outofdate` mark.
 
 #### [build]
 
-##### GnupgHome (default: )
-Provides an override path for the `GNUPGHOME` to use when building packages from the aur.
+##### GpgDir (default: )
+Provides an override path for the GPG home directory used when validating aur package sources.
 See explanations of `--homedir` and `${GNUPGHOME}` in the gpg man pages for more details.
+Will be overridden by `--build_gpgdir` argument.
 
 ##### KeepBuildDir (default: no)
 Don't remove `~/.cache/pikaur/build/${PACKAGE_NAME}` directory between the builds.
@@ -331,11 +332,11 @@ cd .. && rm -rf <package> # Remove the temp directory
 ```
 
 ##### How to add additional trusted keys when building with systemd dynamic users?
-When using systemd dynamic users, there is no a persistent home directory and therefore no persist home. You can set the configuration option build.gnupghome in the root pikaur configuration file `/root/.config/pikaur.conf` The below example configures makepkg to use a hypothetical gpg home directory at `/etc/pikaur.d/gnupg` when validating source files.
+When using systemd dynamic users, by default, there is not a persistent user or gpg home directory. You can set the path to a persistent gpg home directory using the cli argument `--build_gpgdir`. Alternatively, you can set a permanent default with the configuration option `[build] gpgdir` in the root pikaur configuration file `/root/.config/pikaur.conf` The below example configures makepkg to use a hypothetical gpg home directory at `/etc/pikaur.d/gnupg` when validating source files.
 
 ```ini
 [build]
-gnupghome=/etc/pikaur.d/gnupg
+gpgdir=/etc/pikaur.d/gnupg
 ```
 
 You can initialize a minimal gnupghome at the example path by executing the below commands as root.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ When doing sysupgrade ignore AUR packages which have `outofdate` mark.
 
 #### [build]
 
-##### GnupgHome (default: None)
+##### GnupgHome (default: )
 Provides an override path for the `GNUPGHOME` to use when building packages from the aur.
 See explanations of `--homedir` and `${GNUPGHOME}` in the gpg man pages for more details.
 
@@ -328,6 +328,22 @@ pikaur -Rns <package> # Uninstal current version
 pikaur -P  # Uninstal current version
 makepkg -si # If previous command failed to install
 cd .. && rm -rf <package> # Remove the temp directory
+```
+
+##### How to add additional trusted keys when building with systemd dynamic users?
+When using systemd dynamic users, there is no a persistent home directory and therefore no persist home. You can set the configuration option build.gnupghome in the root pikaur configuration file `/root/.config/pikaur.conf` The below example configures makepkg to use a hypothetical gpg home directory at `/etc/pikaur.d/gnupg` when validating source files.
+
+```ini
+[build]
+gnupghome=/etc/pikaur.d/gnupg
+```
+
+You can initialize a minimal gnupghome at the example path by executing the below commands as root.
+
+```sh
+export GNUPGHOME="/etc/pikaur.d/gnupg"
+mkdir -p "${GNUPGHOME}"
+gpg --batch --passphrase '' --quick-gen-key "pikaur@localhost" rsa sign 0
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ When doing sysupgrade ignore AUR packages which have `outofdate` mark.
 
 #### [build]
 
+##### GnupgHome (default: None)
+Provides an override path for the `GNUPGHOME` to use when building packages from the aur.
+See explanations of `--homedir` and `${GNUPGHOME}` in the gpg man pages for more details.
+
 ##### KeepBuildDir (default: no)
 Don't remove `~/.cache/pikaur/build/${PACKAGE_NAME}` directory between the builds.
 Will be overridden by `-k/--keepbuild` flag.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ When doing sysupgrade ignore AUR packages which have `outofdate` mark.
 
 #### [build]
 
-##### GpgDir (default: )
+##### GpgDir (default: ) (root default: /etc/pacman.d/gnupg)
 Provides an override path for the GPG home directory used when validating aur package sources.
 See explanations of `--homedir` and `${GNUPGHOME}` in the gpg man pages for more details.
 Will be overridden by `--build_gpgdir` argument.

--- a/pikaur/args.py
+++ b/pikaur/args.py
@@ -82,7 +82,7 @@ PACMAN_STR_OPTS: ArgSchema = [
 
 def get_pikaur_str_opts() -> ArgSchema:
     return [
-        (None, 'build-gpgdir', None),
+        (None, 'build-gpgdir', PikaurConfig().build.GpgDir.get_str()),
         (None, 'mflags', None),
         (None, 'makepkg-config', None),
         (None, 'makepkg-path', None),

--- a/pikaur/args.py
+++ b/pikaur/args.py
@@ -82,6 +82,7 @@ PACMAN_STR_OPTS: ArgSchema = [
 
 def get_pikaur_str_opts() -> ArgSchema:
     return [
+        (None, 'build-gpgdir', None),
         (None, 'mflags', None),
         (None, 'makepkg-config', None),
         (None, 'makepkg-path', None),

--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -671,16 +671,24 @@ class PackageBuild(DataType):  # pylint: disable=too-many-public-methods
                 cmd_args += ['--ignorearch']
             if skip_check:
                 cmd_args += ['--nocheck']
-            cmd_args = isolate_root_cmd(cmd_args, cwd=self.build_dir)
+
+            env = {}
+
+            if PikaurConfig().build.GnupgHome.get_str() != '':
+                env['GNUPGHOME'] = PikaurConfig().build.GnupgHome.get_str()
+
+            cmd_args = isolate_root_cmd(cmd_args, cwd=self.build_dir, env=env)
             spawn_kwargs: Dict[str, Any] = {}
             if self.args.hide_build_log:
                 spawn_kwargs = dict(
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE
                 )
+
             result = interactive_spawn(
                 cmd_args,
                 cwd=self.build_dir,
+                env=env,
                 **spawn_kwargs
             )
             print_stdout()

--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -146,7 +146,7 @@ class PackageBuild(DataType):  # pylint: disable=too-many-public-methods
             raise NotImplementedError('Either `package_names` or `pkgbuild_path` should be set')
 
         self.build_dir = os.path.join(BUILD_CACHE_PATH, self.package_base)
-        self.build_gpgdir = self.args.build_gpgdir or PikaurConfig().build.GpgDir.get_str()
+        self.build_gpgdir = self.args.build_gpgdir
         self.built_packages_paths = {}
         self.keep_build_dir = self.args.keepbuild or (
             is_devel_pkg(self.package_base) and PikaurConfig().build.KeepDevBuildDir.get_bool()

--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -98,6 +98,7 @@ class PackageBuild(DataType):  # pylint: disable=too-many-public-methods
     repo_path: str
     pkgbuild_path: str
     build_dir: str
+    build_gpgdir: str
     built_packages_paths: Dict[str, str]
 
     reviewed = False
@@ -145,6 +146,7 @@ class PackageBuild(DataType):  # pylint: disable=too-many-public-methods
             raise NotImplementedError('Either `package_names` or `pkgbuild_path` should be set')
 
         self.build_dir = os.path.join(BUILD_CACHE_PATH, self.package_base)
+        self.build_gpgdir = self.args.build_gpgdir or PikaurConfig().build.GpgDir.get_str()
         self.built_packages_paths = {}
         self.keep_build_dir = self.args.keepbuild or (
             is_devel_pkg(self.package_base) and PikaurConfig().build.KeepDevBuildDir.get_bool()
@@ -673,9 +675,8 @@ class PackageBuild(DataType):  # pylint: disable=too-many-public-methods
                 cmd_args += ['--nocheck']
 
             env = {}
-
-            if PikaurConfig().build.GnupgHome.get_str() != '':
-                env['GNUPGHOME'] = PikaurConfig().build.GnupgHome.get_str()
+            if self.build_gpgdir != '':
+                env['GNUPGHOME'] = self.build_gpgdir
 
             cmd_args = isolate_root_cmd(cmd_args, cwd=self.build_dir, env=env)
             spawn_kwargs: Dict[str, Any] = {}

--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -688,7 +688,7 @@ class PackageBuild(DataType):  # pylint: disable=too-many-public-methods
             result = interactive_spawn(
                 cmd_args,
                 cwd=self.build_dir,
-                env=env,
+                env={**os.environ, **env},
                 **spawn_kwargs
             )
             print_stdout()

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -103,6 +103,10 @@ CONFIG_SCHEMA: Dict[str, Any] = {
             'type': 'bool',
             'default': 'no',
         },
+        'GnupgHome': {
+            'type': 'str',
+            'default': ''
+        },
         'SkipFailedBuild': {
             'type': 'bool',
             'default': 'no',

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -103,7 +103,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
             'type': 'bool',
             'default': 'no',
         },
-        'GnupgHome': {
+        'GpgDir': {
             'type': 'str',
             'default': ''
         },

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -105,7 +105,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
         },
         'GnupgHome': {
             'type': 'str',
-            'default': ('/etc/pacman.d/gnupg/' if RUNNING_AS_ROOT else '')
+            'default': ''
         },
         'SkipFailedBuild': {
             'type': 'bool',

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -105,7 +105,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
         },
         'GpgDir': {
             'type': 'str',
-            'default': ''
+            'default': ('/etc/pacman.d/gnupg/' if RUNNING_AS_ROOT else '')
         },
         'SkipFailedBuild': {
             'type': 'bool',

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -105,7 +105,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
         },
         'GnupgHome': {
             'type': 'str',
-            'default': ''
+            'default': ('/etc/pacman.d/gnupg/' if RUNNING_AS_ROOT else '')
         },
         'SkipFailedBuild': {
             'type': 'bool',

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -227,7 +227,7 @@ def isolate_root_cmd(cmd: List[str], cwd=None, env=None) -> List[str]:
     ]
     if env is not None:
         for env_var_name, env_var_value in env.items():
-            base_root_isolator += [ '-E', f'{env_var_name}={env_var_value}' ]
+            base_root_isolator += ['-E', f'{env_var_name}={env_var_value}']
     if cwd is not None:
         base_root_isolator += ['-p', 'WorkingDirectory=' + os.path.abspath(cwd)]
     for env_var_name in (

--- a/pikaur/core.py
+++ b/pikaur/core.py
@@ -214,7 +214,7 @@ def running_as_root() -> bool:
     return os.geteuid() == 0
 
 
-def isolate_root_cmd(cmd: List[str], cwd=None) -> List[str]:
+def isolate_root_cmd(cmd: List[str], cwd=None, env=None) -> List[str]:
     if not running_as_root():
         return cmd
     base_root_isolator = [
@@ -225,6 +225,9 @@ def isolate_root_cmd(cmd: List[str], cwd=None) -> List[str]:
         '-p', 'CacheDirectory=pikaur',
         '-E', 'HOME=/tmp',
     ]
+    if env is not None:
+        for env_var_name, env_var_value in env.items():
+            base_root_isolator += [ '-E', f'{env_var_name}={env_var_value}' ]
     if cwd is not None:
         base_root_isolator += ['-p', 'WorkingDirectory=' + os.path.abspath(cwd)]
     for env_var_name in (

--- a/pikaur/help_cli.py
+++ b/pikaur/help_cli.py
@@ -79,7 +79,8 @@ def cli_print_help() -> None:
             ('', '--makepkg-path=<path>', translate("override path to makepkg executable")),
             ('', '--pikaur-config=<path>', translate("path to custom pikaur config")),
             ('', '--dynamic-users', translate("always isolate with systemd dynamic users")),
-            ('', '--build-gpgdir=<path>', translate("set GnuPG home directory used when validating package sources")),
+            ('', '--build-gpgdir=<path>',
+                translate("set GnuPG home directory used when validating package sources")),
         ]
     if args.sync:
         pikaur_options_help += [

--- a/pikaur/help_cli.py
+++ b/pikaur/help_cli.py
@@ -79,7 +79,7 @@ def cli_print_help() -> None:
             ('', '--makepkg-path=<path>', translate("override path to makepkg executable")),
             ('', '--pikaur-config=<path>', translate("path to custom pikaur config")),
             ('', '--dynamic-users', translate("always isolate with systemd dynamic users")),
-            ('', '--build-gpgdir=<path>', translate("set an alternate home directory for GnuPG used when validating package sources")),
+            ('', '--build-gpgdir=<path>', translate("set GnuPG home directory used when validating package sources")),
         ]
     if args.sync:
         pikaur_options_help += [

--- a/pikaur/help_cli.py
+++ b/pikaur/help_cli.py
@@ -79,6 +79,7 @@ def cli_print_help() -> None:
             ('', '--makepkg-path=<path>', translate("override path to makepkg executable")),
             ('', '--pikaur-config=<path>', translate("path to custom pikaur config")),
             ('', '--dynamic-users', translate("always isolate with systemd dynamic users")),
+            ('', '--build-gpgdir=<path>', translate("set an alternate home directory for GnuPG used when validating package sources")),
         ]
     if args.sync:
         pikaur_options_help += [

--- a/pikaur_test/test_basic.py
+++ b/pikaur_test/test_basic.py
@@ -3,8 +3,9 @@
 # pylint: disable=invalid-name
 
 import os
+import tempfile
 
-from pikaur_test.helpers import PikaurDbTestCase, pikaur, fake_pikaur
+from pikaur_test.helpers import PikaurDbTestCase, pikaur, fake_pikaur, spawn
 
 
 class InstallTest(PikaurDbTestCase):
@@ -100,6 +101,31 @@ class InstallTest(PikaurDbTestCase):
         pikaur(f'-P ./{pkg_base}/PKGBUILD --noconfirm --install')
         self.assertInstalled(pkg_name1)
         self.assertInstalled(pkg_name2)
+
+    def test_pkgbuild_custom_gpgdir(self):
+        pkg_name = "zfs-utils"
+        pkg_keys = ["4F3BA9AB6D1F8D683DC2DFB56AD860EED4598027", "C33DF142657ED1F7C328A2960AB9E991C6AF658B"]
+        keyserver = "hkp://keyserver.ubuntu.com:11371"
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            commands = [
+                f"gpg --homedir {tmpdirname} --batch --passphrase  --quick-generate-key 'pikaur@localhost' rsa sign 0",
+                *map(lambda key: f'gpg --homedir {tmpdirname} --keyserver {keyserver} --receive-keys {key}', pkg_keys),
+                *map(lambda key: f'gpg --homedir {tmpdirname} --quick-lsign-key {key}', pkg_keys),
+                f"chmod 755 {tmpdirname}",
+                f"chmod 644 {tmpdirname}/pubring.gpg",
+                f"chmod 644 {tmpdirname}/trust.gpg"
+            ]
+
+            print(f'Configuring {tmpdirname}')
+            for command in commands:
+                spawn(command)
+
+            pikaur(f'--build-gpgdir {tmpdirname} -S {pkg_name}')
+            self.assertInstalled(pkg_name)
+
+        # Cleanup to ensure no impact on other tests
+        self.remove_if_installed(pkg_name)
 
     def test_conflicting_aur_packages(self):
         conflicting_aur_package1 = 'resvg'


### PR DESCRIPTION
Initialize GNUPGHOME from new config file option, build.GnupgHome. 

This PR should provide a minimal resolution for https://github.com/actionless/pikaur/issues/340

If the changes seem reasonable, I'll add test case(s). I'm also open to adding a related command line argument, but don't require it for my own use case.