### PR TITLE
Skip dependency checking for print-format invocations (Fixes #665, #656)

### DIFF
--- a/pikaur/pacman.py
+++ b/pikaur/pacman.py
@@ -398,7 +398,7 @@ class PackageDB(PackageDBCommon):
             return cached_pkg
         results: List[PacmanPrint] = []
         proc = spawn(
-            cmd_args + ['--print-format', '%r/%n']
+            cmd_args + ['--print-format', '%r/%n', '--nodeps']
         )
         if proc.returncode != 0:
             raise DependencyError(proc.stderr_text + proc.stdout_text)
@@ -462,7 +462,7 @@ class PackageDB(PackageDBCommon):
             return not_found_pkg_names
 
         results = spawn(
-            get_pacman_command() + ['--sync', '--print-format=%%'] + pkg_names_to_check
+            get_pacman_command() + ['--sync', '--print-format=%%', '--nodeps'] + pkg_names_to_check
         ).stderr_text.splitlines()
         new_not_found_pkg_names = []
         for result in results:


### PR DESCRIPTION
Method collects information about packages, so disable pacman checking for dependencies. Without this, conflicts would cause pikaur to report the requested package as missing.

- [x] check if `pacman.get_not_found_repo_packages()` should also use --nodeps