### PR TITLE
fix(pkgbuild): add missing python-setuptools build dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,6 +23,7 @@ makedepends=(
 	'python-build'
 	'python-installer'
 	'python-markdown-it-py'
+        'python-setuptools'
 )
 optdepends=(
 	'asp: for ABS support in -G/--getpkgbuild operation'


### PR DESCRIPTION
Bulding the 1.14.2-1 package failed with `ModuleNotFoundError: No module named 'setuptools'`.  The full build log is below.  The build succeeded after adding `python-setuptools` to the `makedepends` list.

```
:: Starting the build:
==> Making package: pikaur 1.14.2-1 (Sat 26 Nov 2022 11:32:50 AM)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Downloading pikaur-1.14.2.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2140k  100 2140k    0     0  2783k      0 --:--:-- --:--:-- --:--:-- 11.6M
==> Validating source files with b2sums...
    pikaur-1.14.2.tar.gz ... Passed
==> Extracting sources...
  -> Extracting pikaur-1.14.2.tar.gz with bsdtar
==> Starting build()...
# find pikaur -type f -name '*.py' -not -name 'argparse.py' \
        #
find pikaur -type f -name '*.py' \
        | xargs xgettext --language=python --add-comments --sort-output \
                --default-domain=pikaur --from-code=UTF-8 \
                --keyword='translate' --keyword='translate_many:1,2' \
                --output=locale/pikaur.pot
test -f locale/fr.po || msginit --locale=fr --no-translator --input=locale/pikaur.pot --output=locale/fr.po
msgmerge --update locale/fr.po locale/pikaur.pot
.................... done.
msgfmt -o locale/fr.mo locale/fr.po
test -f locale/ru.po || msginit --locale=ru --no-translator --input=locale/pikaur.pot --output=locale/ru.po
msgmerge --update locale/ru.po locale/pikaur.pot
....................... done.
msgfmt -o locale/ru.mo locale/ru.po
test -f locale/pt.po || msginit --locale=pt --no-translator --input=locale/pikaur.pot --output=locale/pt.po
msgmerge --update locale/pt.po locale/pikaur.pot
............................... done.
msgfmt -o locale/pt.mo locale/pt.po
test -f locale/pt_BR.po || msginit --locale=pt_BR --no-translator --input=locale/pikaur.pot --output=locale/pt_BR.po
msgmerge --update locale/pt_BR.po locale/pikaur.pot
....................... done.
msgfmt -o locale/pt_BR.mo locale/pt_BR.po
test -f locale/de.po || msginit --locale=de --no-translator --input=locale/pikaur.pot --output=locale/de.po
msgmerge --update locale/de.po locale/pikaur.pot
....................... done.
msgfmt -o locale/de.mo locale/de.po
test -f locale/is.po || msginit --locale=is --no-translator --input=locale/pikaur.pot --output=locale/is.po
msgmerge --update locale/is.po locale/pikaur.pot
....................... done.
msgfmt -o locale/is.mo locale/is.po
test -f locale/tr.po || msginit --locale=tr --no-translator --input=locale/pikaur.pot --output=locale/tr.po
msgmerge --update locale/tr.po locale/pikaur.pot
............................ done.
msgfmt -o locale/tr.mo locale/tr.po
test -f locale/da.po || msginit --locale=da --no-translator --input=locale/pikaur.pot --output=locale/da.po
msgmerge --update locale/da.po locale/pikaur.pot
......................... done.
msgfmt -o locale/da.mo locale/da.po
test -f locale/nl.po || msginit --locale=nl --no-translator --input=locale/pikaur.pot --output=locale/nl.po
msgmerge --update locale/nl.po locale/pikaur.pot
....................... done.
msgfmt -o locale/nl.mo locale/nl.po
test -f locale/es.po || msginit --locale=es --no-translator --input=locale/pikaur.pot --output=locale/es.po
msgmerge --update locale/es.po locale/pikaur.pot
....................... done.
msgfmt -o locale/es.mo locale/es.po
test -f locale/zh_CN.po || msginit --locale=zh_CN --no-translator --input=locale/pikaur.pot --output=locale/zh_CN.po
msgmerge --update locale/zh_CN.po locale/pikaur.pot
....................... done.
msgfmt -o locale/zh_CN.mo locale/zh_CN.po
test -f locale/it.po || msginit --locale=it --no-translator --input=locale/pikaur.pot --output=locale/it.po
msgmerge --update locale/it.po locale/pikaur.pot
....................... done.
msgfmt -o locale/it.mo locale/it.po
test -f locale/ja.po || msginit --locale=ja --no-translator --input=locale/pikaur.pot --output=locale/ja.po
msgmerge --update locale/ja.po locale/pikaur.pot
....................... done.
msgfmt -o locale/ja.mo locale/ja.po
test -f locale/uk.po || msginit --locale=uk --no-translator --input=locale/pikaur.pot --output=locale/uk.po
msgmerge --update locale/uk.po locale/pikaur.pot
....................... done.
msgfmt -o locale/uk.mo locale/uk.po
/usr/bin/python ./maintenance_scripts/pikaman.py README.md pikaur.1
sed -i \
        -e '/coveralls/d' \
        -e '/Screenshot/d' \
        pikaur.1
mkdir -p dist/usr/bin
sed \
        -e "s/%PYTHON_BUILD_VERSION%/$(python -c 'import sys ; print(f"{sys.version_info.major}.{sys.version_info.minor}")')/g" \
        packaging/usr/bin/pikaur > dist/usr/bin/pikaur
chmod +x dist/usr/bin/pikaur
* Getting build dependencies for wheel...

Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/pep517/wrappers.py", line 319, in _call_hook
    raise BackendUnavailable(data.get('traceback', ''))
pep517.wrappers.BackendUnavailable: Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/pep517/in_process/_in_process.py", line 77, in _build_backend
    obj = import_module(mod_path)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'setuptools'

ERROR Backend 'setuptools.build_meta:__legacy__' is not available.
==> ERROR: A failure occurred in build().
    Aborting...

Command 'makepkg --force' failed to execute.
:: Try recovering?
[R] retry build
[p] PGP check skip
[c] checksums skip
[f] skip 'check()' function of PKGBUILD
[n] skip 'prepare()' function of PKGBUILD
[i] ignore architecture
[d] delete build dir and try again
[e] edit PKGBUILD
------------------------
[s] skip building this package
[a] abort building all the packages
```