### PR TITLE
add dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = [
+  "wheel", 
+  "build", 
+  "installer", 
+  "markdown-it-py"]
 [tool.ruff]
 line-length = 100
 select = ["E", "F", "Q", "I", "D", "U", "N", "S", "C", "B", "A", "T", "ANN", "YTT", "RUF", "M", "W"]


### PR DESCRIPTION
Adding the dependencies previously mentioned in `PKGBUILD` to the python build definition in `pyproject.toml` as well solves the issue in #686 for me.

When adding the dependencies, I tried following the documentation at https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/.