### PR TITLE
Fix KeyError  when a optdepend can't be found in AUR

### DIFF
--- a/pikaur/install_info_fetcher.py
+++ b/pikaur/install_info_fetcher.py
@@ -528,9 +528,10 @@ Gonna fetch install info for:
                 self.package_is_ignored(pkg_name)
             ):
                 del aur_updates_install_info_by_name[pkg_name]
-            for pkg_list in self.pkgbuilds_packagelists.values():
-                if pkg_name in pkg_list:
-                    del aur_updates_install_info_by_name[pkg_name]
+            else:
+                for pkg_list in self.pkgbuilds_packagelists.values():
+                    if pkg_name in pkg_list:
+                        del aur_updates_install_info_by_name[pkg_name]
         self.aur_updates_install_info += list(aur_updates_install_info_by_name.values())
         logger.debug("got AUR pkgs install info: {}", self.aur_updates_install_info)
 


### PR DESCRIPTION
During updating a package with a broken optdepend I ran into this issue:

```
1d [oskar:~]└2 125 % pikaur -Syu
:: Paketdatenbanken werden synchronisiert …
 core ist aktuell
 extra ist aktuell
 community ist aktuell
 multilib ist aktuell
 oscloud ist aktuell
 home_ungoogled_chr...  1411,0   B  16,6 KiB/s 00:00 [----------------------------] 100%

:: Starte komplettes AUR-Upgrade...
Lese Repository-Paketdatenbank...
Lese lokale Paketdatenbank...
Lese AUR Paketinfos...
:: Warnung: Folgende Pakete können nicht im AUR gefunden werden:
    cower
    glusterfs-fake
    intel-hybrid-codec-driver
    ipw2200-fw
    js78
    kalarmcal
    kde-l10n-de
    lib32-libnm-glib
    lib32-libva1
    lib32-libwrap
    lib32-openssl-1.0
    libnm-glib
    libopenaptx
    libpipewire02
    libva1
    libvterm01
    mariadb-fake
    nodejs-lts-erbium
    orion
    pth
    python-jsonrpc-server
    python-language-server
    python-pep517
    python-sip-pyqt5
    tsc
    vim-trailing-whitespace
    yaourt
Löse AUR-Abhängigkeiten auf...
:: Fehler: Kann Abhängigkeiten für AUR-Paket 'kipi-plugins' nicht auflösen:
:: Fehler: Fehlende Abhängigkeiten für kipi-plugins
:: Warnung: Folgendes Paket kann nicht im AUR gefunden werden:
    libmediawiki
:: Try recovering kipi-plugins?
[b] PKGBUILD bearbeiten
[u] überspringe dieses Paket
[A] abbrechen
> b
'kipi-plugins' in '/home/oskar/.local/share/pikaur/aur_repos/kipi-plugins' kann nicht vo
m AUR bezogen werden:

Fehler: Pull mit Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit vorgem
erkt sind.
Fehler: Bitte committen Sie die Änderungen oder benutzen Sie "stash".

:: Versuchen, wiederherzustellen?
[T] try again
[c] git checkout -- '*'
[e] entferne Verzeichnis und klone erneut
[p] git stash && ... && git stash pop
[u] überspringe dieses Paket
[a] abbrechen
> c
:: Warnung: Installations-Informationen haben sich für Paket kipi-plugins geändert (oder
 neue Abhängigkeiten gefunden)
Lese AUR Paketinfos...
:: Warnung: Folgende Pakete können nicht im AUR gefunden werden:
    cower
    glusterfs-fake
    intel-hybrid-codec-driver
    ipw2200-fw
    js78
    kalarmcal
    kde-l10n-de
    lib32-libnm-glib
    lib32-libva1
    lib32-libwrap
    lib32-openssl-1.0
    libnm-glib
    libopenaptx
    libpipewire02
    libva1
    libvterm01
    mariadb-fake
    nodejs-lts-erbium
    orion
    pth
    python-jsonrpc-server
    python-language-server
    python-pep517
    python-sip-pyqt5
    tsc
    vim-trailing-whitespace
    yaourt
Löse AUR-Abhängigkeiten auf...
:: Fehler: Kann Abhängigkeiten für AUR-Paket 'kipi-plugins' nicht auflösen:
:: Fehler: Fehlende Abhängigkeiten für kipi-plugins
:: Warnung: Folgendes Paket kann nicht im AUR gefunden werden:
    libmediawiki
:: Try recovering kipi-plugins?
[b] PKGBUILD bearbeiten
[u] überspringe dieses Paket
[A] abbrechen
> b
:: Warnung: PKGBUILD ist unverändert nach Bearbeiten
Lese AUR Paketinfos...
:: Warnung: Folgende Pakete können nicht im AUR gefunden werden:
    cower
    glusterfs-fake
    intel-hybrid-codec-driver
    ipw2200-fw
    js78
    kalarmcal
    kde-l10n-de
    lib32-libnm-glib
    lib32-libva1
    lib32-libwrap
    lib32-openssl-1.0
    libnm-glib
    libopenaptx
    libpipewire02
    libva1
    libvterm01
    mariadb-fake
    nodejs-lts-erbium
    orion
    pth
    python-jsonrpc-server
    python-language-server
    python-pep517
    python-sip-pyqt5
    tsc
    vim-trailing-whitespace
    yaourt
  File "/usr/lib/python3.11/site-packages/pikaur/main.py", line 441, in main
    cli_entry_point()
  File "/usr/lib/python3.11/site-packages/pikaur/main.py", line 337, in cli_entry_point
    execute_pikaur_operation(pikaur_operation=pikaur_operation, require_sudo=require_sud
o)
  File "/usr/lib/python3.11/site-packages/pikaur/main.py", line 274, in execute_pikaur_o
peration
    pikaur_operation()
  File "/usr/lib/python3.11/site-packages/pikaur/main.py", line 164, in cli_install_pack
ages
    InstallPackagesCLI()
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 177, in __init__
    self.main_sequence()
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 215, in main_sequ
ence
    self.get_all_packages_info()
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 308, in get_all_p
ackages_info
    self.aur_pkg_not_found_prompt(pkg_name)
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 271, in aur_pkg_n
ot_found_prompt
    self.handle_pkgbuild_changed(pkg_build)
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 901, in handle_pk
gbuild_changed
    self.main_sequence()
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 215, in main_sequ
ence
    self.get_all_packages_info()
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 308, in get_all_p
ackages_info
    self.aur_pkg_not_found_prompt(pkg_name)
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 274, in aur_pkg_n
ot_found_prompt
    self.main_sequence()
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 215, in main_sequ
ence
    self.get_all_packages_info()
  File "/usr/lib/python3.11/site-packages/pikaur/install_cli.py", line 293, in get_all_p
ackages_info
    self.install_info = InstallInfoFetcher(
                        ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/pikaur/install_info_fetcher.py", line 85, in _
_init__
    self.get_all_packages_info()
  File "/usr/lib/python3.11/site-packages/pikaur/install_info_fetcher.py", line 228, in
get_all_packages_info
    self.get_aur_pkgs_info(self.not_found_repo_pkgs_names)
  File "/usr/lib/python3.11/site-packages/pikaur/install_info_fetcher.py", line 533, in
get_aur_pkgs_info
    del aur_updates_install_info_by_name[pkg_name]
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^

KeyError: 'kipi-plugins'
```

Which is fixed by this, but probably I shouldn't have to choose the edit option twice in the 1st place. The patch is still relevant as the code should never allow deleting a pair twice.