### PR TITLE
Fix off by one error

### DIFF
--- a/pikaur/main.py
+++ b/pikaur/main.py
@@ -201,7 +201,7 @@ def cli_dynamic_select() -> None:  # pragma: no cover
             for idx in selected_pkgs_idx:
                 if not 0 <= idx < len(packages):
                     print_error(translate("invalid value: {} is not between {} and {}").format(
-                        idx + 1, 1, len(packages) + 1,
+                        idx + 1, 1, len(packages),
                     ))
                     restart_prompt = True
             if restart_prompt:


### PR DESCRIPTION
When giving the wrong number while choosing from several packages, it doesn't give an error message with the wrong number range.