### PR TITLE
chore(locale): update es.po and fr.po

### DIFF
--- a/locale/da.po
+++ b/locale/da.po
@@ -820,7 +820,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/de.po
+++ b/locale/de.po
@@ -828,7 +828,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -820,7 +820,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-10 15:19+0200\n"
+"POT-Creation-Date: 2024-07-11 05:42+0200\n"
 "PO-Revision-Date: 2018-06-05 22:38+0200\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -831,11 +831,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: pikaur/main.py:481
-#, python-brace-format
+#, fuzzy, python-brace-format
 msgid ""
 "{privilege_escalation_tool} is not part of minimal arch default setup, be "
 "aware that you could run into potential problems."
-msgstr "{privilege_escalation_tool} no forma parte de la configuración mínima por defecto de arch, puede tener problemas."
+msgstr ""
+"{privilege_escalation_tool} no forma parte de la configuración mínima por "
+"defecto de Arch, puede tener problemas."
 
 #: pikaur/news.py:68 pikaur/news.py:106
 msgid "Could not fetch archlinux.org news"

--- a/locale/es.po
+++ b/locale/es.po
@@ -833,7 +833,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 "{privilege_escalation_tool} no forma parte de la configuración mínima por "

--- a/locale/es.po
+++ b/locale/es.po
@@ -386,7 +386,7 @@ msgstr "'{class_name}' no tiene definido el atributo '{key}'."
 #: pikaur/core.py:316
 #, python-brace-format
 msgid "Error opening file: {file_path}"
-msgstr ""
+msgstr "Error al abrir el archivo: {file_path}"
 
 #: pikaur/core.py:346
 msgid "executable not found"
@@ -395,7 +395,7 @@ msgstr "ejecutable no encontrado"
 #: pikaur/core.py:364
 #, python-brace-format
 msgid "Can't change owner to {user_id}: {exc}"
-msgstr ""
+msgstr "No se puede cambiar el propietario de {user_id}: {exc}"
 
 #: pikaur/getpkgbuild_cli.py:49
 #, python-brace-format
@@ -444,20 +444,19 @@ msgstr "Opciones específicas pikaur:"
 
 #: pikaur/i18n.py:32
 msgid "Read damn arch-wiki before borking your computer:"
-msgstr ""
+msgstr "Lee la maldita arch-wiki antes de estropear tu ordenador:"
 
 #: pikaur/i18n.py:33
 msgid "(Also, don't report any issues to pikaur, if ure seeing this message)"
-msgstr ""
+msgstr "(No reportes problemas a pikaur si ves este mensaje)"
 
 #: pikaur/info_cli.py:24
 msgid "AUR Git URL"
 msgstr "URL Git de AUR"
 
 #: pikaur/info_cli.py:25
-#, fuzzy
 msgid "AUR Web URL"
-msgstr "URL Git de AUR"
+msgstr "URL Web de AUR"
 
 #. "aur_id": translate("id"),
 #: pikaur/info_cli.py:27
@@ -836,7 +835,7 @@ msgstr ""
 msgid ""
 "{privilege_escalation_tool} is not part of minimal arch default setup, be "
 "aware that you could run into potential problems."
-msgstr ""
+msgstr "{privilege_escalation_tool} no forma parte de la configuración mínima por defecto de arch, puede tener problemas."
 
 #: pikaur/news.py:68 pikaur/news.py:106
 msgid "Could not fetch archlinux.org news"

--- a/locale/es.po
+++ b/locale/es.po
@@ -820,7 +820,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-11 05:42+0200\n"
+"POT-Creation-Date: 2024-07-11 05:53+0200\n"
 "PO-Revision-Date: 2018-06-05 22:38+0200\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -831,13 +831,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: pikaur/main.py:481
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid ""
 "{privilege_escalation_tool} is not part of minimal arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 "{privilege_escalation_tool} no forma parte de la configuración mínima por "
-"defecto de Arch, puede tener problemas."
+"defecto de Arch, debe tener en cuenta que podría encontrarse con posibles "
+"problemas."
 
 #: pikaur/news.py:68 pikaur/news.py:106
 msgid "Could not fetch archlinux.org news"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -836,7 +836,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 "{privilege_escalation_tool} ne fait pas partie de la configuration minimale "

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -391,7 +391,7 @@ msgstr "'{class_name}' n'a pas d'attribut '{key}' défini."
 #: pikaur/core.py:316
 #, python-brace-format
 msgid "Error opening file: {file_path}"
-msgstr ""
+msgstr "Erreur à l'ouverture du fichier : {file_path}"
 
 #: pikaur/core.py:346
 msgid "executable not found"
@@ -400,7 +400,7 @@ msgstr "exécutable non trouvé"
 #: pikaur/core.py:364
 #, python-brace-format
 msgid "Can't change owner to {user_id}: {exc}"
-msgstr ""
+msgstr "Impossible de changer le propriétaire pour {user_id} : {exc}"
 
 #: pikaur/getpkgbuild_cli.py:49
 #, python-brace-format
@@ -449,20 +449,19 @@ msgstr "Options spécifiques à pikaur :"
 
 #: pikaur/i18n.py:32
 msgid "Read damn arch-wiki before borking your computer:"
-msgstr ""
+msgstr "Lisez ce foutu arch-wiki avant de planter votre ordinateur :"
 
 #: pikaur/i18n.py:33
 msgid "(Also, don't report any issues to pikaur, if ure seeing this message)"
-msgstr ""
+msgstr "(Ne signalez pas de problèmes à pikaur si vous voyez ce message)"
 
 #: pikaur/info_cli.py:24
 msgid "AUR Git URL"
 msgstr "URL Git de l'AUR"
 
 #: pikaur/info_cli.py:25
-#, fuzzy
 msgid "AUR Web URL"
-msgstr "URL Git de l'AUR"
+msgstr "URL Web de l'AUR"
 
 #. "aur_id": translate("id"),
 #: pikaur/info_cli.py:27
@@ -839,7 +838,7 @@ msgstr ""
 msgid ""
 "{privilege_escalation_tool} is not part of minimal arch default setup, be "
 "aware that you could run into potential problems."
-msgstr ""
+msgstr "{privilege_escalation_tool} ne fait pas partie de la configuration minimale par défaut d'arch, sachez que vous risquez de rencontrer des problèmes."
 
 #: pikaur/news.py:68 pikaur/news.py:106
 msgid "Could not fetch archlinux.org news"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -823,7 +823,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-11 05:42+0200\n"
+"POT-Creation-Date: 2024-07-11 05:53+0200\n"
 "PO-Revision-Date: 2018-03-03 16:29+0100\n"
 "Last-Translator: Bundy01\n"
 "Language-Team: none\n"
@@ -834,13 +834,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: pikaur/main.py:481
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid ""
 "{privilege_escalation_tool} is not part of minimal arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 "{privilege_escalation_tool} ne fait pas partie de la configuration minimale "
-"par défaut d'Arch, sachez que vous risquez de rencontrer des problèmes."
+"par défaut d'Arch, sachez que vous pourriez rencontrer des problèmes "
+"potentiels."
 
 #: pikaur/news.py:68 pikaur/news.py:106
 msgid "Could not fetch archlinux.org news"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -823,7 +823,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-10 15:19+0200\n"
+"POT-Creation-Date: 2024-07-11 05:42+0200\n"
 "PO-Revision-Date: 2018-03-03 16:29+0100\n"
 "Last-Translator: Bundy01\n"
 "Language-Team: none\n"
@@ -834,11 +834,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: pikaur/main.py:481
-#, python-brace-format
+#, fuzzy, python-brace-format
 msgid ""
 "{privilege_escalation_tool} is not part of minimal arch default setup, be "
 "aware that you could run into potential problems."
-msgstr "{privilege_escalation_tool} ne fait pas partie de la configuration minimale par défaut d'arch, sachez que vous risquez de rencontrer des problèmes."
+msgstr ""
+"{privilege_escalation_tool} ne fait pas partie de la configuration minimale "
+"par défaut d'Arch, sachez que vous risquez de rencontrer des problèmes."
 
 #: pikaur/news.py:68 pikaur/news.py:106
 msgid "Could not fetch archlinux.org news"

--- a/locale/is.po
+++ b/locale/is.po
@@ -819,7 +819,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/it.po
+++ b/locale/it.po
@@ -865,7 +865,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -824,7 +824,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -829,7 +829,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/pt.po
+++ b/locale/pt.po
@@ -823,7 +823,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -830,7 +830,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -836,7 +836,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -822,7 +822,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -821,7 +821,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -833,7 +833,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -813,7 +813,7 @@ msgstr ""
 #: pikaur/main.py:481
 #, python-brace-format
 msgid ""
-"{privilege_escalation_tool} is not part of minimal arch default setup, be "
+"{privilege_escalation_tool} is not part of minimal Arch default setup, be "
 "aware that you could run into potential problems."
 msgstr ""
 

--- a/pikaur/main.py
+++ b/pikaur/main.py
@@ -478,7 +478,7 @@ def check_runtime_deps() -> None:
                 ] if privilege_escalation_tool == "sudo" else [
                     "",
                     translate(
-                        "{privilege_escalation_tool} is not part of minimal arch default setup,"
+                        "{privilege_escalation_tool} is not part of minimal Arch default setup,"
                         " be aware that you could run into potential problems.",
                     ).format(privilege_escalation_tool=privilege_escalation_tool),
                     "",


### PR DESCRIPTION
I have a doubt about a translation:
```
"{privilege_escalation_tool} is not part of minimal arch default setup, be "
"aware that you could run into potential problems."
```

Does `arch` mean `Archlinux` or `architecture`?

**If it's `architecture`, I'll have to redo the translation: doesn't validate**

To make it clearer in the future, I suggest you capitalize `Arch` for `Archlinux`.

Regards.