### PR TITLE
fix(news, install_cli): fix bug that prevented confirmation from doing anything

### DIFF
--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -543,17 +543,16 @@ class InstallPackagesCLI:  # noqa: PLR0904
                 f"\n{color_line('::', ColorsHighlight.blue)}"
                 f" {bold_line(options_line1)}"
             )
+            answers = translate("y").upper() + translate("n") + translate("v") + translate("m")
             if self.news and self.news.any_news:
                 options_news = translate("[c]onfirm Arch NEWS as read")
                 prompt += (
                     f"\n{color_line('::', ColorsHighlight.blue)}"
                     f" {bold_line(options_news)}"
                 )
+                answers += translate("c")
             prompt += "\n>> "
-            return get_input(
-                prompt,
-                translate("y").upper() + translate("n") + translate("v") + translate("m"),
-            )
+            return get_input(prompt, answers)
 
         if self.args.noconfirm:
             _print_sysupgrade()


### PR DESCRIPTION
Fixes a bug that caused pikaur to exit immediately when the user hit `c` to confirm that they have read the news, and to redisplay the same news the next time.