### PR TITLE
add ability to add gnupg public keys in building git packages

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -18,6 +18,7 @@ b2sums=(
 depends=(
 	'pyalpm'
 	'git'
+	'python-gnupg'
 )
 makedepends=(
 	'python-wheel'

--- a/PKGBUILD_dev_deps
+++ b/PKGBUILD_dev_deps
@@ -21,6 +21,7 @@ depends=(
 	# linting:
 	ruff flake8 python-pylint mypy vulture bandit shellcheck python-validate-pyproject shellcheck_makefile-git
 	'python-coveralls'
+	'python-gnupg'
 	# pikaur opt deps:
 	'devtools'
 	'python-pysocks'


### PR DESCRIPTION
Useful for certain packages that have publicpgpkey arrays in their PKGBUILD file. Enables one to avoid having to quit out of the pikaur process to add the key using gpg.

This requires the python-gnupg package - the PKGBUILD file has been updated to reflect this.