### PR TITLE
fix(build): don't run prepare() twice

### DIFF
--- a/pikaur/build.py
+++ b/pikaur/build.py
@@ -352,7 +352,7 @@ class PackageBuild(ComparableType):
         )
         pkgver_result = joined_spawn(
             isolate_root_cmd(
-                [*MakePkgCommand.get(), "--nobuild", "--nocheck", "--nodeps"],
+                [*MakePkgCommand.get(), "--noprepare", "--nobuild", "--nocheck", "--nodeps"],
                 cwd=self.build_dir,
             ),
             cwd=self.build_dir,


### PR DESCRIPTION
Calling prepare more than once might cause build failures if a patch file is applied creating new files. Avoid running it just to update `pkgver`.

See also [these comments on zfs-dkms-staging-git](https://aur.archlinux.org/packages/zfs-dkms-staging-git#comment-1068144).