### PR TITLE
Add support to GitCmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Don't prompt to show the build files diff.
 Will be overridden by `--nodiff` flag.
 
 
-##### GitCmd (default: git -C {{repo_path}} diff --ignore-space-change --ignore-all-space {{last_installed_hash}} {{current_hash}} -- .)
+##### GitDiffCmd (default: git -C {{repo_path}} diff --ignore-space-change --ignore-all-space {{last_installed_hash}} {{current_hash}} -- .)
 Command to execute to get the PKGBUILD diff.
 Allow some variables:
  - `{{repo_path}}`: Path where git repo is.

--- a/README.md
+++ b/README.md
@@ -161,9 +161,13 @@ Will be overridden by `--noedit` and `--edit` flags.
 Don't prompt to show the build files diff.
 Will be overridden by `--nodiff` flag.
 
-##### GitDiffArgs (default: --ignore-space-change,--ignore-all-space)
-Flags to be passed to `git diff` command when reviewing build files.
-Should be separated by commas (`,`).
+
+##### GitCmd (default: git -C {{repo_path}} diff --ignore-space-change --ignore-all-space {{last_installed_hash}} {{current_hash}} -- .)
+Command to execute to get the PKGBUILD diff.
+Allow some variables:
+ - `{{repo_path}}`: Path where git repo is.
+ - `{{last_installed_hash}}`: Hash of the currently installed commit.
+ - `{{current_hash}}`: Hash of the new version.
 
 ##### DiffPager (default: auto)
 Wherever to use `less` pager when viewing AUR packages diff. Choices are `always`, `auto` or `never`.

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -470,6 +470,14 @@ class ConfigSchema(UserDict[str, ConfigSection]):
                     "GitDiffArgs": {
                         "data_type": STR,
                         "default": "--ignore-space-change,--ignore-all-space",
+                        "deprecated": {
+                            "section": "review",
+                            "option": "GitCmd",
+                            "transform": (
+                                lambda old_value, _config:
+                                "git -C {{repo_path}} diff " + old_value.replace(",", " ") + " {{last_install_hash}} {{current_hash}} -- ."
+                            ),
+                        }
                     },
                     "GitCmd": {
                         "data_type": STR,

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -471,6 +471,10 @@ class ConfigSchema(UserDict[str, ConfigSection]):
                         "data_type": STR,
                         "default": "--ignore-space-change,--ignore-all-space",
                     },
+                    "GitCmd": {
+                        "data_type": STR,
+                        "default": "git -C {{repo_path}} diff --ignore-space-change --ignore-all-space {{last_install_hash}} {{current_hash}} -- .",
+                    },
                     "DiffPager": {
                         "data_type": STR,
                         "default": DiffPagerValues.AUTO,

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -485,7 +485,7 @@ class ConfigSchema(UserDict[str, ConfigSection]):
                         "default": (
                             "git -C {{repo_path}} diff --ignore-space-change "
                             "--ignore-all-space {{last_install_hash}} {{current_hash}} -- ."
-                            ),
+                        ),
                     },
                     "DiffPager": {
                         "data_type": STR,

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -472,7 +472,7 @@ class ConfigSchema(UserDict[str, ConfigSection]):
                         "default": "--ignore-space-change,--ignore-all-space",
                         "deprecated": {
                             "section": "review",
-                            "option": "GitCmd",
+                            "option": "GitDiffCmd",
                             "transform": (
                                 lambda old_value, _config:
                                 "git -C {{repo_path}} diff " + old_value.replace(",", " ")
@@ -480,7 +480,7 @@ class ConfigSchema(UserDict[str, ConfigSection]):
                             ),
                         },
                     },
-                    "GitCmd": {
+                    "GitDiffCmd": {
                         "data_type": STR,
                         "default": (
                             "git -C {{repo_path}} diff --ignore-space-change "

--- a/pikaur/config.py
+++ b/pikaur/config.py
@@ -475,13 +475,17 @@ class ConfigSchema(UserDict[str, ConfigSection]):
                             "option": "GitCmd",
                             "transform": (
                                 lambda old_value, _config:
-                                "git -C {{repo_path}} diff " + old_value.replace(",", " ") + " {{last_install_hash}} {{current_hash}} -- ."
+                                "git -C {{repo_path}} diff " + old_value.replace(",", " ")
+                                + " {{last_install_hash}} {{current_hash}} -- ."
                             ),
-                        }
+                        },
                     },
                     "GitCmd": {
                         "data_type": STR,
-                        "default": "git -C {{repo_path}} diff --ignore-space-change --ignore-all-space {{last_install_hash}} {{current_hash}} -- .",
+                        "default": (
+                            "git -C {{repo_path}} diff --ignore-space-change "
+                            "--ignore-all-space {{last_install_hash}} {{current_hash}} -- ."
+                            ),
                     },
                     "DiffPager": {
                         "data_type": STR,

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -1053,7 +1053,7 @@ class InstallPackagesCLI:
                 for s in shlex.split(git_cmd):
                     git_args += [s.replace("{{repo_path}}", str(pkg_build.repo_path))
                         .replace("{{last_install_hash}}", pkg_build.last_installed_hash)
-                        .replace("{{current_hash}}", pkg_build.current_hash)
+                        .replace("{{current_hash}}", pkg_build.current_hash),
                         ]
 
                 for file_path in PikaurConfig().review.HideDiffFiles.get_str().split(","):

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -1050,8 +1050,8 @@ class InstallPackagesCLI:
                 elif diff_pager == DiffPagerValues.NEVER:
                     git_args = ["env", "GIT_PAGER=cat"]
                 git_cmd = PikaurConfig().review.GitCmd.get_str()
-                for s in shlex.split(git_cmd):
-                    git_args += [s.replace("{{repo_path}}", str(pkg_build.repo_path))
+                for arg in shlex.split(git_cmd):
+                    git_args += [arg.replace("{{repo_path}}", str(pkg_build.repo_path))
                                  .replace("{{last_install_hash}}", pkg_build.last_installed_hash)
                                  .replace("{{current_hash}}", pkg_build.current_hash),
                                  ]

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -1054,7 +1054,6 @@ class InstallPackagesCLI:
                         git_cmd.replace("{{repo_path}}", str(pkg_build.repo_path))
                         .replace("{{last_install_hash}}", pkg_build.last_installed_hash)
                         .replace("{{current_hash}}", pkg_build.current_hash)
-                        .replace("{{git_diff_args}}", PikaurConfig().review.GitDiffArgs.get_str().replace(",", " "))
                     )
 
                 for file_path in PikaurConfig().review.HideDiffFiles.get_str().split(","):

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -1048,15 +1048,17 @@ class InstallPackagesCLI:
                     git_args = ["env", "GIT_PAGER=less -+F"]
                 elif diff_pager == DiffPagerValues.NEVER:
                     git_args = ["env", "GIT_PAGER=cat"]
-                git_args += [
-                    "git",
-                    "-C", str(pkg_build.repo_path),
-                    "diff",
-                    *PikaurConfig().review.GitDiffArgs.get_str().split(","),
-                    pkg_build.last_installed_hash,
-                    pkg_build.current_hash,
-                    "--", ".",
-                ]
+                git_cmd = PikaurConfig().review.GitCmd.get_str()
+                test = ( 
+                        git_cmd.replace("{{repo_path}}", str(pkg_build.repo_path))
+                        .replace("{{last_install_hash}}", pkg_build.last_installed_hash)
+                        .replace("{{current_hash}}", pkg_build.current_hash)
+                    ).split('\"')
+                for i, item in enumerate(test):
+                    if i % 2 == 0:
+                        git_args += item.split()
+                    else:
+                        git_args += [item]
                 for file_path in PikaurConfig().review.HideDiffFiles.get_str().split(","):
                     if file_path:
                         git_args += [

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -1052,9 +1052,9 @@ class InstallPackagesCLI:
                 git_cmd = PikaurConfig().review.GitCmd.get_str()
                 for s in shlex.split(git_cmd):
                     git_args += [s.replace("{{repo_path}}", str(pkg_build.repo_path))
-                        .replace("{{last_install_hash}}", pkg_build.last_installed_hash)
-                        .replace("{{current_hash}}", pkg_build.current_hash),
-                        ]
+                                 .replace("{{last_install_hash}}", pkg_build.last_installed_hash)
+                                 .replace("{{current_hash}}", pkg_build.current_hash),
+                                 ]
 
                 for file_path in PikaurConfig().review.HideDiffFiles.get_str().split(","):
                     if file_path:

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -1049,7 +1049,7 @@ class InstallPackagesCLI:
                     git_args = ["env", "GIT_PAGER=less -+F"]
                 elif diff_pager == DiffPagerValues.NEVER:
                     git_args = ["env", "GIT_PAGER=cat"]
-                git_cmd = PikaurConfig().review.GitCmd.get_str()
+                git_cmd = PikaurConfig().review.GitDiffCmd.get_str()
                 for arg in shlex.split(git_cmd):
                     git_args += [arg.replace("{{repo_path}}", str(pkg_build.repo_path))
                                  .replace("{{last_install_hash}}", pkg_build.last_installed_hash)

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -4,6 +4,7 @@
 import contextlib
 import hashlib
 import itertools
+import shlex
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -1049,16 +1050,13 @@ class InstallPackagesCLI:
                 elif diff_pager == DiffPagerValues.NEVER:
                     git_args = ["env", "GIT_PAGER=cat"]
                 git_cmd = PikaurConfig().review.GitCmd.get_str()
-                test = ( 
+                git_args += shlex.split(
                         git_cmd.replace("{{repo_path}}", str(pkg_build.repo_path))
                         .replace("{{last_install_hash}}", pkg_build.last_installed_hash)
                         .replace("{{current_hash}}", pkg_build.current_hash)
-                    ).split('\"')
-                for i, item in enumerate(test):
-                    if i % 2 == 0:
-                        git_args += item.split()
-                    else:
-                        git_args += [item]
+                        .replace("{{git_diff_args}}", PikaurConfig().review.GitDiffArgs.get_str().replace(",", " "))
+                    )
+
                 for file_path in PikaurConfig().review.HideDiffFiles.get_str().split(","):
                     if file_path:
                         git_args += [

--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -1050,11 +1050,11 @@ class InstallPackagesCLI:
                 elif diff_pager == DiffPagerValues.NEVER:
                     git_args = ["env", "GIT_PAGER=cat"]
                 git_cmd = PikaurConfig().review.GitCmd.get_str()
-                git_args += shlex.split(
-                        git_cmd.replace("{{repo_path}}", str(pkg_build.repo_path))
+                for s in shlex.split(git_cmd):
+                    git_args += [s.replace("{{repo_path}}", str(pkg_build.repo_path))
                         .replace("{{last_install_hash}}", pkg_build.last_installed_hash)
                         .replace("{{current_hash}}", pkg_build.current_hash)
-                    )
+                        ]
 
                 for file_path in PikaurConfig().review.HideDiffFiles.get_str().split(","):
                     if file_path:


### PR DESCRIPTION
### Goal
I wanna use difftastic to see PKGBUILD files diff

### Solution
I allow to specify the git command to use `git -C {{repo_path}} diff --ignore-space-change --ignore-all-space {{last_install_hash}} {{current_hash}} -- .` 
It allso has some "params" for variables.

Originally I implemented a "GitDiffExternalTool" but then I realize any new feature we would need yet an other params so instead I went with something more generic

### Looking for feedback
So this solution works, I didn't test it like crazy yet, I'm looking on feedback like is this okay to let the user specify the full git command? This also deprecate the GitDiffArgs param, I could also put it as a replacable var? Or I can go back to a more specific approach of a GitDiffExternalTool.