### PR TITLE
fix: use package base for provides mapping after cloning

### DIFF
--- a/pikaur/install_cli.py
+++ b/pikaur/install_cli.py
@@ -847,10 +847,22 @@ class InstallPackagesCLI:
             if cloned_pkgbuilds:
                 logger.debug("cloned_pkgbuilds={}", cloned_pkgbuilds)
                 pkgbuilds_by_name.update(cloned_pkgbuilds)
+                # Build reverse mapping from package base to PackageBuild
+                # for the provided-name lookup (info.package.name may not
+                # match a key in cloned_pkgbuilds when a virtual/provided
+                # name is requested, e.g. systemd-libs-selinux vs
+                # systemd-selinux).
+                builds_by_base = {
+                    pb.package_base: pb
+                    for pb in cloned_pkgbuilds.values()
+                }
                 for info in clone_infos:
+                    pkgbuild = builds_by_base.get(info.package.packagebase)
+                    if pkgbuild is None:
+                        continue
                     for provided_str in info.package.provides:
                         provided_name = VersionMatcher(provided_str).pkg_name
-                        pkgbuilds_by_provides[provided_name] = cloned_pkgbuilds[info.package.name]
+                        pkgbuilds_by_provides[provided_name] = pkgbuild
             for pkg_list in (self.aur_packages_names, self.aur_deps_names):
                 self._find_extra_aur_build_deps(
                     all_package_builds={


### PR DESCRIPTION
## Summary

Fixes a `KeyError` in `get_package_builds()` when a package is requested by a provided name that differs from the AUR package name.

## Problem

When installing a package like `systemd-libs-selinux`, the AUR package that provides it may have a different name (e.g., `systemd-selinux`). After cloning, `cloned_pkgbuilds` is keyed by the AUR package name, but the code looks up `info.package.name` (the user-requested name), causing a `KeyError`.

## Fix

Look up the `PackageBuild` via its `packagebase` (which is stable regardless of which name was requested) instead of directly indexing `cloned_pkgbuilds` by package name.

## Reproduction

```bash
pikaur --noconfirm --noprogressbar --mflags=--noconfirm --mflags=--skippgpcheck -ySw systemd-selinux
# KeyError: 'systemd-libs-selinux'
```

Closes #917
